### PR TITLE
CI/QA: fix testVersion for PHPCompatibility

### DIFF
--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -33,9 +33,6 @@
 	#############################################################################
 	-->
 
-	<!-- Support PHP 5.6 or higher. -->
-	<config name="testVersion" value="5.6-"/>
-
 	<rule ref="Yoast">
 		<!-- Duplicate classes is by design and part of the cross-version compatibility mechanism. -->
 		<exclude name="Generic.Classes.DuplicateClassName"/>

--- a/composer.json
+++ b/composer.json
@@ -53,7 +53,7 @@
             "@php ./vendor/php-parallel-lint/php-parallel-lint/parallel-lint . -e php --exclude vendor --exclude .git --exclude src/TestCases/TestCasePHPUnitGte8.php --exclude src/TestListeners/TestListenerDefaultImplementationPHPUnitGte7.php"
         ],
         "check-cs": [
-            "@php ./vendor/squizlabs/php_codesniffer/bin/phpcs"
+            "@php ./vendor/squizlabs/php_codesniffer/bin/phpcs --runtime-set testVersion 5.5-"
         ],
         "fix-cs": [
             "@php ./vendor/squizlabs/php_codesniffer/bin/phpcbf"


### PR DESCRIPTION
This library supports PHP >= 5.5, but the default `testVersion` as set in YoastCS is `5.6-`.
Overruling the `testVersion` from within a custom ruleset is currently not possible. This is a known issue in PHPCS itself and a fix is expected to be included with PHPCS 4.x.

In the mean time, as a work-around, the `testVersion` can be overruled from the command-line.