### PR TITLE
README: add FAQ section covering functionality removed from PHPUnit

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Set of polyfills for changed PHPUnit functionality to allow for creating PHPUnit
     - [TestCases](#testcases)
     - [TestListener](#testlistener)
 * [Using this library](#using-this-library)
+* [Frequently Asked Questions](#frequently-asked-questions)
 * [Contributing](#contributing)
 * [License](#license)
 
@@ -491,6 +492,23 @@ class FooTest extends TestCase
     }
 }
 ```
+
+
+Frequently Asked Questions
+-------
+
+### Q: Will this package polyfill functionality which was removed from PHPUnit ?
+
+As a rule of thumb, removed functionality will not be polyfilled in this package.
+
+For frequently used, removed PHPUnit functionality, "helpers" may be provided. These _helpers_ are only intended as an interim solution to allow users of this package more time to refactor their tests away from the removed functionality.
+
+#### Removed functionality without PHPUnit native replacement
+
+| PHPUnit | Removed               | Issue     | Remarks                |
+|---------|-----------------------|-----------|------------------------|
+| 9.0     | `assertArraySubset()` | [#1](https://github.com/Yoast/PHPUnit-Polyfills/issues/1) | The [`dms/phpunit-arraysubset-asserts`](https://packagist.org/packages/dms/phpunit-arraysubset-asserts) package polyfills this functionality.<br/>As of [version 0.3.0](https://github.com/rdohms/phpunit-arraysubset-asserts/releases/tag/v0.3.0) this package can be installed in combination with PHP 5.4 - current and PHPUnit 4.8.36/5.7.21 - current.<br/>Alternatively, tests can be refactored using the patterns outlined in [issue #1](https://github.com/Yoast/PHPUnit-Polyfills/issues/1).
+| 9.0     | `assertAttribute*()`  | [#2](https://github.com/Yoast/PHPUnit-Polyfills/issues/2) | Refactor the tests to not directly test private/protected properties.<br/>As an interim solution, the [`Yoast\PHPUnitPolyfills\Helpers\AssertAttributeHelper`](#yoastphpunitpolyfillshelpersassertattributehelper) trait is available.
 
 
 Contributing


### PR DESCRIPTION
... with alternatives which can be used to replace that functionality.