### PR TITLE
Handle strings containing empty strings assertions

### DIFF
--- a/src/Polyfills/AssertStringContains.php
+++ b/src/Polyfills/AssertStringContains.php
@@ -24,6 +24,12 @@ trait AssertStringContains {
 	 * @return void
 	 */
 	public static function assertStringContainsString( $needle, $haystack, $message = '' ) {
+		// Replicate fix added to PHPUnit 6.4.2.
+		if ( '' === $needle ) {
+			static::assertTrue( true, $message );
+			return;
+		}
+
 		static::assertContains( $needle, $haystack, $message );
 	}
 
@@ -37,6 +43,12 @@ trait AssertStringContains {
 	 * @return void
 	 */
 	public static function assertStringContainsStringIgnoringCase( $needle, $haystack, $message = '' ) {
+		// Replicate fix added to PHPUnit 6.4.2.
+		if ( '' === $needle ) {
+			static::assertTrue( true, $message );
+			return;
+		}
+
 		static::assertContains( $needle, $haystack, $message, true );
 	}
 
@@ -50,6 +62,12 @@ trait AssertStringContains {
 	 * @return void
 	 */
 	public static function assertStringNotContainsString( $needle, $haystack, $message = '' ) {
+		// Replicate fix added to PHPUnit 6.4.2.
+		if ( '' === $needle ) {
+			static::assertTrue( true, $message );
+			return;
+		}
+
 		static::assertNotContains( $needle, $haystack, $message );
 	}
 
@@ -63,6 +81,12 @@ trait AssertStringContains {
 	 * @return void
 	 */
 	public static function assertStringNotContainsStringIgnoringCase( $needle, $haystack, $message = '' ) {
+		// Replicate fix added to PHPUnit 6.4.2.
+		if ( '' === $needle ) {
+			static::assertTrue( true, $message );
+			return;
+		}
+
 		static::assertNotContains( $needle, $haystack, $message, true );
 	}
 }

--- a/src/Polyfills/AssertStringContains.php
+++ b/src/Polyfills/AssertStringContains.php
@@ -25,9 +25,8 @@ trait AssertStringContains {
 	 */
 	public static function assertStringContainsString( $needle, $haystack, $message = '' ) {
 		// Replicate fix added to PHPUnit 6.4.2.
-		if ( '' === $needle ) {
-			static::assertTrue( true, $message );
-			return;
+		if ( self::needsEmptyStringFix( $needle, false ) ) {
+			self::markTestSkipped( 'Asserting a string contains an empty string, which always "exists" in any other string.');
 		}
 
 		static::assertContains( $needle, $haystack, $message );
@@ -44,9 +43,8 @@ trait AssertStringContains {
 	 */
 	public static function assertStringContainsStringIgnoringCase( $needle, $haystack, $message = '' ) {
 		// Replicate fix added to PHPUnit 6.4.2.
-		if ( '' === $needle ) {
-			static::assertTrue( true, $message );
-			return;
+		if ( self::needsEmptyStringFix( $needle, false ) ) {
+			self::markTestSkipped( 'Asserting a string contains an empty string, which always "exists" in any other string.');
 		}
 
 		static::assertContains( $needle, $haystack, $message, true );
@@ -63,9 +61,8 @@ trait AssertStringContains {
 	 */
 	public static function assertStringNotContainsString( $needle, $haystack, $message = '' ) {
 		// Replicate fix added to PHPUnit 6.4.2.
-		if ( '' === $needle ) {
-			static::assertTrue( true, $message );
-			return;
+		if ( self::needsEmptyStringFix( $needle, true ) ) {
+			self::markTestSkipped( 'Asserting a string contains an empty string, which always "exists" in any other string.');
 		}
 
 		static::assertNotContains( $needle, $haystack, $message );
@@ -82,11 +79,53 @@ trait AssertStringContains {
 	 */
 	public static function assertStringNotContainsStringIgnoringCase( $needle, $haystack, $message = '' ) {
 		// Replicate fix added to PHPUnit 6.4.2.
-		if ( '' === $needle ) {
-			static::assertTrue( true, $message );
-			return;
+		if ( self::needsEmptyStringFix( $needle, true ) ) {
+			self::markTestSkipped( 'Asserting a string contains an empty string, which always "exists" in any other string.');
 		}
 
 		static::assertNotContains( $needle, $haystack, $message, true );
+	}
+
+	/**
+	 * Decide if a fix for an empty needle string is needed.
+	 *
+	 * PHPUnit 6.4.2 added a fix to gracefully handle the case when an empty string was passed to
+	 * `assertStringContainsString()` and variant assertions. Versions earlier than that gave a "mb_strpos(): Empty
+	 * delimiter" error instead.
+	 *
+	 * If the needle string is empty, and the PHPUnit version is found to be lower than 6.4.2, or 6.4.2 or above and
+	 * part of a NotContains assertion, then return true, which will result in tests marked as skipped.
+	 *
+	 * To not have tests marked as skipped, test authors should ensure the needle string
+	 * passed to the assertion is not empty.
+	 *
+	 * @param string $needle_string String that should be looked for in haystack string.
+	 * @param bool   $is_negative   Whether assertion is negative i.e. NotContains
+	 *
+	 * @return bool True unless the needle string is empty, or PHPUnit is 6.4.2 or later, or
+	 *              PHPUnit version can't be identified.
+	 */
+	protected static function needsEmptyStringFix( $needle_string, $is_negative ) {
+		if ( '' !== $needle_string ) {
+			return false;
+		}
+
+		$phpunit_version = '';
+		if ( class_exists( 'PHPUnit\Runner\Version' ) ) {
+			$phpunit_version = \PHPUnit\Runner\Version::id();
+		} elseif ( class_exists( 'PHPUnit_Runner_Version' ) ) {
+			$phpunit_version = \PHPUnit_Runner_Version::id();
+		}
+
+		// If the version can't be identified, assume everything is good.
+		if ( '' === $phpunit_version ) {
+			return false;
+		}
+
+		if ( ! $is_negative && version_compare( $phpunit_version, '6.4.2', '>=' ) ) {
+			return false;
+		}
+
+		return true;
 	}
 }

--- a/tests/Polyfills/AssertStringContainsTest.php
+++ b/tests/Polyfills/AssertStringContainsTest.php
@@ -49,4 +49,40 @@ class AssertStringContainsTest extends TestCase {
 	public function testAssertStringNotContainsStringIgnoringCase() {
 		$this->assertStringNotContainsStringIgnoringCase( 'Baz', 'foobar' );
 	}
+
+	/**
+	 * Verify availability of the assertStringContainsString() method with empty string.
+	 *
+	 * @return void
+	 */
+	public function testAssertStringContainsEmptyString() {
+		$this->assertStringContainsString( '', 'foobar' );
+	}
+
+	/**
+	 * Verify availability of the assertStringContainsStringIgnoringCase() method with empty string.
+	 *
+	 * @return void
+	 */
+	public function testAssertStringContainsEmptyStringIgnoringCase() {
+		self::assertStringContainsStringIgnoringCase( '', 'foobar' );
+	}
+
+	/**
+	 * Verify availability of the assertStringNotContainsString() method with empty string.
+	 *
+	 * @return void
+	 */
+	public function testAssertStringNotContainsEmptyString() {
+		self::assertStringNotContainsString( '', 'foobar' );
+	}
+
+	/**
+	 * Verify availability of the assertStringNotContainsStringIgnoringCase() method with empty string.
+	 *
+	 * @return void
+	 */
+	public function testAssertStringNotContainsEmptyStringIgnoringCase() {
+		$this->assertStringNotContainsStringIgnoringCase( '', 'foobar' );
+	}
 }

--- a/tests/Polyfills/AssertStringContainsTest.php
+++ b/tests/Polyfills/AssertStringContainsTest.php
@@ -4,6 +4,7 @@ namespace Yoast\PHPUnitPolyfills\Tests\Polyfills;
 
 use PHPUnit\Framework\TestCase;
 use Yoast\PHPUnitPolyfills\Polyfills\AssertStringContains;
+use Yoast\PHPUnitPolyfills\Polyfills\ExpectException;
 
 /**
  * Availability test for the functions polyfilled by the AssertStringContains trait.
@@ -13,6 +14,7 @@ use Yoast\PHPUnitPolyfills\Polyfills\AssertStringContains;
 class AssertStringContainsTest extends TestCase {
 
 	use AssertStringContains;
+	use ExpectException; // Needed for PHPUnit < 5.2.0 support.
 
 	/**
 	 * Verify availability of the assertStringContainsString() method.
@@ -51,38 +53,105 @@ class AssertStringContainsTest extends TestCase {
 	}
 
 	/**
-	 * Verify availability of the assertStringContainsString() method with empty string.
+	 * Verify that the assertStringContainsString() method does not throw a mb_strpos()
+	 * PHP error when passed an empty $needle.
+	 *
+	 * This was possible due to a bug which existed in PHPUnit < 6.4.2.
+	 *
+	 * @link https://github.com/Yoast/PHPUnit-Polyfills/issues/17
+	 * @link https://github.com/sebastianbergmann/phpunit/pull/2778/
+	 *
+	 * @dataProvider dataHaystacks
+	 *
+	 * @param string $haystack Haystack.
 	 *
 	 * @return void
 	 */
-	public function testAssertStringContainsEmptyString() {
-		$this->assertStringContainsString( '', 'foobar' );
+	public function testAssertStringContainsStringEmptyNeedle( $haystack ) {
+		$this->assertStringContainsString( '', $haystack );
 	}
 
 	/**
-	 * Verify availability of the assertStringContainsStringIgnoringCase() method with empty string.
+	 * Verify that the assertStringContainsStringIgnoringCase() method does not throw
+	 * a mb_strpos() PHP error when passed an empty $needle.
+	 *
+	 * This was possible due to a bug which existed in PHPUnit < 6.4.2.
+	 *
+	 * @link https://github.com/Yoast/PHPUnit-Polyfills/issues/17
+	 * @link https://github.com/sebastianbergmann/phpunit/pull/2778/
 	 *
 	 * @return void
 	 */
-	public function testAssertStringContainsEmptyStringIgnoringCase() {
+	public function testAssertStringContainsStringIgnoringCaseEmptyNeedle() {
 		self::assertStringContainsStringIgnoringCase( '', 'foobar' );
 	}
 
 	/**
-	 * Verify availability of the assertStringNotContainsString() method with empty string.
+	 * Verify that the assertStringNotContainsString() method does not throw a mb_strpos()
+	 * PHP error when passed an empty $needle.
+	 *
+	 * This was possible due to a bug which existed in PHPUnit < 6.4.2.
+	 *
+	 * @link https://github.com/Yoast/PHPUnit-Polyfills/issues/17
+	 * @link https://github.com/sebastianbergmann/phpunit/pull/2778/
+	 *
+	 * @dataProvider dataHaystacks
+	 *
+	 * @param string $haystack Haystack.
 	 *
 	 * @return void
 	 */
-	public function testAssertStringNotContainsEmptyString() {
-		self::assertStringNotContainsString( '', 'foobar' );
+	public function testAssertStringNotContainsStringEmptyNeedle( $haystack ) {
+		$msg       = "Failed asserting that '{$haystack}' does not contain \"\".";
+		$exception = 'PHPUnit\Framework\AssertionFailedError';
+		if ( \class_exists( 'PHPUnit_Framework_AssertionFailedError' ) ) {
+			// PHPUnit < 6.
+			$exception = 'PHPUnit_Framework_AssertionFailedError';
+		}
+
+		$this->expectException( $exception );
+		$this->expectExceptionMessage( $msg );
+
+		self::assertStringNotContainsString( '', $haystack );
 	}
 
 	/**
-	 * Verify availability of the assertStringNotContainsStringIgnoringCase() method with empty string.
+	 * Verify that the assertStringNotContainsStringIgnoringCase() method does not throw a mb_strpos()
+	 * PHP error when passed an empty $needle.
+	 *
+	 * This was possible due to a bug which existed in PHPUnit < 6.4.2.
+	 *
+	 * @link https://github.com/Yoast/PHPUnit-Polyfills/issues/17
+	 * @link https://github.com/sebastianbergmann/phpunit/pull/2778/
 	 *
 	 * @return void
 	 */
-	public function testAssertStringNotContainsEmptyStringIgnoringCase() {
-		$this->assertStringNotContainsStringIgnoringCase( '', 'foobar' );
+	public function testAssertStringNotContainsStringIgnoringCaseEmptyNeedle() {
+		$msg       = 'Failed asserting that \'text with whitespace\' does not contain "".';
+		$exception = 'PHPUnit\Framework\AssertionFailedError';
+		if ( \class_exists( 'PHPUnit_Framework_AssertionFailedError' ) ) {
+			// PHPUnit < 6.
+			$exception = 'PHPUnit_Framework_AssertionFailedError';
+		}
+
+		$this->expectException( $exception );
+		$this->expectExceptionMessage( $msg );
+
+		$this->assertStringNotContainsStringIgnoringCase( '', 'text with whitespace' );
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @see testAssertStringContainsStringEmptyNeedle()    For the array format.
+	 * @see testAssertStringNotContainsStringEmptyNeedle() For the array format.
+	 *
+	 * @return array
+	 */
+	public function dataHaystacks() {
+		return [
+			'foobar as haystack' => [ 'foobar' ],
+			'empty haystack'     => [ '' ],
+		];
 	}
 }


### PR DESCRIPTION
PHPUnit 6.4.2 added a fix to gracefully handle the case when an empty string was passed to `assertStringContainsString()` and variant assertions. Versions earlier than that gave a "mb_strpos(): Empty delimiter" error instead.

This change adds a fix to also handle that case, when using PHPUnit-Polyfills with versions of PHPUnit earlier than 6.4.2, and passing an empty needle string.

The use of asserting true is true stops the test from being marked as risky, which is what would happen if we just `return true;`. **This is hacky, and there may be a better way for this.**

Fixes #17.