### PR TITLE
XTestCase: set to lowest possible visibility

### DIFF
--- a/src/TestCases/XTestCase.php
+++ b/src/TestCases/XTestCase.php
@@ -64,7 +64,7 @@ abstract class XTestCase extends PHPUnit_TestCase {
 	 *
 	 * @return void
 	 */
-	public function setUpFixtures() {
+	protected function setUpFixtures() {
 		parent::setUp();
 	}
 
@@ -77,7 +77,7 @@ abstract class XTestCase extends PHPUnit_TestCase {
 	 *
 	 * @return void
 	 */
-	public function tearDownFixtures() {
+	protected function tearDownFixtures() {
 		parent::tearDown();
 	}
 

--- a/tests/TestCases/XTestCaseTest.php
+++ b/tests/TestCases/XTestCaseTest.php
@@ -57,7 +57,7 @@ class XTestCaseTest extends XTestCase {
 	 *
 	 * @return void
 	 */
-	public function setUpFixtures() {
+	protected function setUpFixtures() {
 		parent::setUpFixtures();
 
 		++self::$before;
@@ -70,7 +70,7 @@ class XTestCaseTest extends XTestCase {
 	 *
 	 * @return void
 	 */
-	public function tearDownFixtures() {
+	protected function tearDownFixtures() {
 		++self::$after;
 
 		parent::tearDownFixtures();


### PR DESCRIPTION
This aligns the visibility of the methods in the `XTestCase` class with the minimum acceptable visibility to allow the methods to work.
This also ensures that the visibility used in the class now matches that of the code sample in the README.

| Native method name     | Annotation     | Minimum visibility |
|------------------------|----------------|--------------------|
| `setUpBeforeClass()`   | `@beforeClass` | `public`           |
| `setUp()`              | `@before`      | `protected`        |
| `tearDown()`           | `@after`       | `protected`        |
| `tearDownAfterClass()` | `@afterClass`  | `public`           |

Fixes #10