### PR TITLE
TestCaseTestTrait: add missing tests

### DIFF
--- a/tests/TestCases/TestCaseTestTrait.php
+++ b/tests/TestCases/TestCaseTestTrait.php
@@ -115,7 +115,31 @@ trait TestCaseTestTrait {
 	 *
 	 * @return void
 	 */
-	public function testAssertNan() {
+	public function testAvailabilityAssertNumericTypeTrait() {
 		self::assertNan( \acos( 8 ) );
+	}
+
+	/**
+	 * Test availability of trait polyfilled PHPUnit methods [10].
+	 *
+	 * @return void
+	 *
+	 * @throws Exception For testing purposes.
+	 */
+	public function testAvailabilityExpectExceptionTrait() {
+		$this->expectException( '\Exception' );
+		$this->expectExceptionMessage( 'message' );
+
+		throw new Exception( 'message' );
+	}
+
+	/**
+	 * Verify availability of trait polyfilled PHPUnit methods [11].
+	 *
+	 * @return void
+	 */
+	public function testAvailabilityAssertFileDirectory() {
+		$path = __DIR__ . \DIRECTORY_SEPARATOR;
+		$this->assertDirectoryExists( $path );
 	}
 }


### PR DESCRIPTION
* Commit 057a83d34ab2b27f0b80f6f54d817590db75f7b4 added the `AssertNumericType` trait and a corresponding availability test to the `TestCaseTestTrait`, but the test name did not follow the naming convention used in the file.
* Commit b5372989715ad406358e6924ded0a6e98b3e8014 added the `ExpectException` trait, but did not add a corresponding availability test to the `TestCaseTestTrait`.
* Commit 347c76864e41cf254303fc1cca9f74bb2d41ec5c added the `AssertFileDirectory` trait, but did not add a corresponding availability test to the `TestCaseTestTrait`.

Fixed now.