### PR TITLE
Tests: add bootstrap file

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -3,7 +3,7 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.2/phpunit.xsd"
     backupGlobals="true"
-    bootstrap="./vendor/autoload.php"
+    bootstrap="./tests/bootstrap.php"
     beStrictAboutTestsThatDoNotTestAnything="true"
     colors="true"
     forceCoversAnnotation="true">

--- a/phpunitpolyfills-autoload.php
+++ b/phpunitpolyfills-autoload.php
@@ -342,7 +342,7 @@ if ( \class_exists( 'Yoast\PHPUnitPolyfills\Autoload', false ) === false ) {
 		 * @return void
 		 */
 		public static function loadTestCase() {
-			if ( \class_exists( '\PHPUnit\Runner\Version' ) === false
+			if ( \class_exists( '\PHPUnit_Runner_Version' ) === true
 				|| \version_compare( PHPUnit_Version::id(), '8.0.0', '<' )
 			) {
 				// PHPUnit < 8.0.0.
@@ -360,7 +360,7 @@ if ( \class_exists( 'Yoast\PHPUnitPolyfills\Autoload', false ) === false ) {
 		 * @return void
 		 */
 		public static function loadTestListenerDefaultImplementation() {
-			if ( \class_exists( '\PHPUnit\Runner\Version' ) === false ) {
+			if ( \class_exists( '\PHPUnit_Runner_Version' ) === true ) {
 				/*
 				 * Alias one particular PHPUnit 4/5 class to its PHPUnit >= 6 name.
 				 *

--- a/tests/Polyfills/ExpectExceptionTest.php
+++ b/tests/Polyfills/ExpectExceptionTest.php
@@ -95,9 +95,7 @@ class ExpectExceptionTest extends TestCase {
 	 */
 	public function testExpectExceptionMessageException() {
 		$regex = '`^Argument #1 \([^)]+\) of [^:]+::expectExceptionMessage\(\) must be a string`';
-		if ( \class_exists( '\PHPUnit\Runner\Version' ) === true
-			&& \version_compare( PHPUnit_Version::id(), '7.0.0', '>=' )
-		) {
+		if ( \version_compare( PHPUnit_Version::id(), '7.0.0', '>=' ) ) {
 			$regex = '`^Argument 1 passed to [^:]+::expectExceptionMessage\(\) must be of the type string`';
 			if ( \PHP_MAJOR_VERSION === 8 ) {
 				$regex = '`^[^:]+::expectExceptionMessage\(\): Argument \#1 \([^)]+\) must be of type string`';

--- a/tests/TestListeners/TestListenerTest.php
+++ b/tests/TestListeners/TestListenerTest.php
@@ -3,7 +3,6 @@
 namespace Yoast\PHPUnitPolyfills\Tests\TestListeners;
 
 use PHPUnit\Framework\TestResult;
-use PHPUnit_Framework_TestResult;
 use Yoast\PHPUnitPolyfills\TestCases\TestCase;
 use Yoast\PHPUnitPolyfills\Tests\TestListeners\Fixtures\Failure;
 use Yoast\PHPUnitPolyfills\Tests\TestListeners\Fixtures\Incomplete;
@@ -42,15 +41,7 @@ class TestListenerTest extends TestCase {
 	 * @return void
 	 */
 	protected function set_up() {
-		if ( \class_exists( '\PHPUnit\Framework\TestResult' ) ) {
-			// PHPUnit 6.0.0+.
-			$this->result = new TestResult();
-		}
-		else {
-			// PHPUnit < 6.0.0.
-			$this->result = new PHPUnit_Framework_TestResult();
-		}
-
+		$this->result   = new TestResult();
 		$this->listener = new TestListenerImplementation();
 
 		$this->result->addListener( $this->listener );

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Yoast\PHPUnitPolyfills\Tests;
+
+if ( \defined( '__PHPUNIT_PHAR__' ) ) {
+	require_once \dirname( __DIR__ ) . '/phpunitpolyfills-autoload.php';
+
+	\spl_autoload_register(
+		/**
+		 * Custom PSR-4 based autoloader for test helper files.
+		 *
+		 * @param string $fqClassName The name of the class to load.
+		 *
+		 * @return bool
+		 */
+		static function ( $fqClassName ) {
+			// Only try & load our own classes.
+			if ( \stripos( $fqClassName, 'Yoast\PHPUnitPolyfills\Tests\\' ) !== 0 ) {
+				return false;
+			}
+
+			// Strip namespace prefix 'Yoast\PHPUnitPolyfills\Tests\'.
+			$relativeClass = \substr( $fqClassName, 29 );
+			$file          = \realpath( __DIR__ ) . \DIRECTORY_SEPARATOR
+				. \strtr( $relativeClass, '\\', \DIRECTORY_SEPARATOR ) . '.php';
+
+			if ( \file_exists( $file ) ) {
+				include_once $file;
+				return true;
+			}
+
+			return false;
+		}
+	);
+}
+elseif ( \file_exists( \dirname( __DIR__ ) . '/vendor/autoload.php' ) ) {
+	/*
+	 * Only load the Composer autoload file when running the tests via a Composer
+	 * installed PHPUnit version, otherwise the &@%*& autoloader will block the test run
+	 * when the installed PHPUnit version does not match the PHP version of the test run.
+	 * Big *sigh*.
+	 */
+	require_once \dirname( __DIR__ ) . '/vendor/autoload.php';
+}
+else {
+	echo 'Please run `composer install` before attempting to run the tests.';
+	die( 1 );
+}
+
+/*
+ * Create a number of class aliases for PHPUnit native classes which have been
+ * renamed over time and are only used in the unit tests.
+ */
+if ( \class_exists( 'PHPUnit_Runner_Version' ) === true
+	&& \class_exists( 'PHPUnit\Runner\Version' ) === false
+) {
+	\class_alias( 'PHPUnit_Runner_Version', 'PHPUnit\Runner\Version' );
+}
+
+if ( \class_exists( 'PHPUnit_Framework_TestResult' ) === true
+	&& \class_exists( 'PHPUnit\Framework\TestResult' ) === false
+) {
+	\class_alias( 'PHPUnit_Framework_TestResult', 'PHPUnit\Framework\TestResult' );
+}


### PR DESCRIPTION
## Context

The main reason to add a test bootstrap file is to allow for defining some `class_alias`-es for PHPUnit native classes which are only used in the test suite.
This allows for some minor simplifications to the existing test code and for these same simplifications to be available for future test adjustments (which are needed for PHPUnit 10.0 support).

## Autoloading of the necessary files / Phar compatibility

The XML configuration allows for only one bootstrap file, so adding a `bootstrap` file now means that the Composer `vendor/autoload.php` file has to be loaded from within the `tests/bootstrap.php` file.

This presents a problem when running the tests via a PHPUnit Phar file as the loading of the Composer autoload will block the tests from running if the PHP version used to run the Phar file is not the same PHP version as the one used to run `composer install`.
In that case, the test run will exit before it starts with an error along the lines of:
```
Fatal error: Composer detected issues in your platform: Your Composer dependencies require a PHP version ">= 7.3.0". You are running 7.0.33. in ./vendor/composer/platform_check.php on line 24
```

To get round this conundrum, the bootstrap file will load the Composer autoload file conditionally: only when the tests are not run via a Phar.

When the tests are run via a Phar, the Polyfill autoload file will be hard-required and a custom autoloader function will take care of loading test helper files which are not automatically loaded by PHPUnit, like the Fixture classes and the `Yoast\PHPUnitPolyfills\Tests\TestCases\TestCaseTestTrait`.

## Version checks in the `phpunitpolyfills-autoload.php` file

As the `PHPUnit_Runner_Version` will be aliased to `PHPUnit\Runner\Version` in the test bootstrap file, it will - for the purposes of our tests - always exist.

In PHPUnit itself, the `PHPUnit_Runner_Version` class existed prior to PHPUnit 6.0.0, the `PHPUnit\Runner\Version` class as of PHPUnit 6.0.0. They have no overlap in tagged releases.

The Polyfill autoload file relies (relied) on only one of the class names existing, while with the change to the bootstrap file, this is no longer correct as in the context of PHPUnit 4.x and 5.x both class names will exist, while in the context of PHPUnit >= 6.0, only the namespaced name will exist.

Either way, this means that we have to (and safely can) reverse the condition used in the `phpunitpolyfills-autoload.php` file from checking whether the PHPUnit 6.0+ class name does not exists to checking whether the PHPUnit < 6.0 class name _does_ exist.

## Other

Includes removing work-arounds for the different class names in individual test classes.,