### PR TITLE
CI/QA: add experimental build against PHPUnit 10.0 (unreleased)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,13 +15,19 @@ jobs:
     strategy:
       matrix:
         php: ['5.4', '5.5', '5.6', '7.0', '7.1', '7.2', '7.3', '7.4', '8.0']
+        phpunit: ['auto']
         experimental: [false]
 
         include:
           - php: '8.1'
+            phpunit: 'auto'
             experimental: true
 
-    name: "Tests: PHP ${{ matrix.php }}"
+          - php: '8.0'
+            phpunit: '^10.0'
+            experimental: true
+
+    name: "Tests: PHP ${{ matrix.php }} - PHPUnit: ${{matrix.phpunit}}"
 
     continue-on-error: ${{ matrix.experimental }}
 
@@ -34,6 +40,10 @@ jobs:
         with:
           php-version: ${{ matrix.php }}
           coverage: none
+
+      - name: 'Composer: set PHPUnit version for tests'
+        if: ${{ matrix.phpunit != 'auto' }}
+        run: composer require --no-update phpunit/phpunit:"${{ matrix.phpunit }}"
 
       # Install dependencies and handle caching in one go.
       # @link https://github.com/marketplace/actions/install-composer-dependencies


### PR DESCRIPTION
This build is - for now - allowed to fail while support for PHPUnit 10.0 is being added to the repo.