### PR TITLE
AssertFileDirectoryTest: allow for running the tests on PHPUnit 10.0.0

### DIFF
--- a/tests/Polyfills/AssertFileDirectoryTest.php
+++ b/tests/Polyfills/AssertFileDirectoryTest.php
@@ -78,6 +78,8 @@ class AssertFileDirectoryTest extends TestCase {
 	 *
 	 * This exception was thrown until PHP 7.0.0. Since PHP 7.0.0, a PHP native TypeError will
 	 * be thrown based on the type declaration.
+	 *
+	 * @requires PHPUnit < 9.99.99
 	 */
 	public function testAssertNotIsReadableException() {
 		try {
@@ -160,6 +162,8 @@ class AssertFileDirectoryTest extends TestCase {
 	 *
 	 * This exception was thrown until PHP 7.0.0. Since PHP 7.0.0, a PHP native TypeError will
 	 * be thrown based on the type declaration.
+	 *
+	 * @requires PHPUnit < 9.99.99
 	 */
 	public function testAssertNotIsWritableException() {
 		try {
@@ -242,6 +246,8 @@ class AssertFileDirectoryTest extends TestCase {
 	 *
 	 * This exception was thrown until PHP 7.0.0. Since PHP 7.0.0, a PHP native TypeError will
 	 * be thrown based on the type declaration.
+	 *
+	 * @requires PHPUnit < 9.99.99
 	 */
 	public function testAssertDirectoryNotExistsException() {
 		try {


### PR DESCRIPTION
Selectively skip some tests from the `AssertFileDirectoryTest` class.

These tests test that a method which was available between PHPUnit 5.6.0 - 9.x is polyfilled correctly for PHPUnit < 5.6.0.

As these methods have been removed in PHPUnit 10.0.0 in favour of assertions with better names, these tests will fail on PHPUnit 10.0.0.

This is not an issue, as the methods with the new names have also been polyfilled and those tests _do_ pass on PHPUnit 10.0.0.

So if people want their tests to be able to run on PHPUnit 10.0.0, they should use the new names of the methods and all will be good.

This is already [documented as such in the README](https://github.com/Yoast/PHPUnit-Polyfills#use-with-phpunit--570).

This affects the following methods:

| Old name                     | New name                        |
|------------------------------|---------------------------------|
| `assertNotIsReadable()`      | `assertIsNotReadable()`         |
| `assertNotIsWritable()`      | `assertIsNotWritable()`         |
| `assertDirectoryNotExists()` | `assertDirectoryDoesNotExist()` |