### PR TITLE
TestListenerTest: fix PHPUnit 10.0.0 compatibility

### DIFF
--- a/tests/TestListeners/TestListenerTest.php
+++ b/tests/TestListeners/TestListenerTest.php
@@ -53,7 +53,7 @@ class TestListenerTest extends TestCase {
 	 * @return void
 	 */
 	public function testError() {
-		$test = new TestError();
+		$test = new TestError( 'runTest' );
 		$test->run( $this->result );
 
 		$this->assertSame( 1, $this->listener->startTestCount, 'test start count failed' );
@@ -72,7 +72,7 @@ class TestListenerTest extends TestCase {
 	 * @return void
 	 */
 	public function testWarning() {
-		$test = new Warning();
+		$test = new Warning( 'runTest' );
 		$test->run( $this->result );
 
 		$this->assertSame( 1, $this->listener->startTestCount, 'test start count failed' );
@@ -86,7 +86,7 @@ class TestListenerTest extends TestCase {
 	 * @return void
 	 */
 	public function testFailure() {
-		$test = new Failure();
+		$test = new Failure( 'runTest' );
 		$test->run( $this->result );
 
 		$this->assertSame( 1, $this->listener->startTestCount, 'test start count failed' );
@@ -100,7 +100,7 @@ class TestListenerTest extends TestCase {
 	 * @return void
 	 */
 	public function testIncomplete() {
-		$test = new Incomplete();
+		$test = new Incomplete( 'runTest' );
 		$test->run( $this->result );
 
 		$this->assertSame( 1, $this->listener->startTestCount, 'test start count failed' );
@@ -118,7 +118,7 @@ class TestListenerTest extends TestCase {
 	 * @return void
 	 */
 	public function testRisky() {
-		$test = new Risky();
+		$test = new Risky( 'runTest' );
 		$test->run( $this->result );
 
 		$this->assertSame( 1, $this->listener->startTestCount, 'test start count failed' );
@@ -132,7 +132,7 @@ class TestListenerTest extends TestCase {
 	 * @return void
 	 */
 	public function testSkipped() {
-		$test = new Skipped();
+		$test = new Skipped( 'runTest' );
 		$test->run( $this->result );
 
 		$this->assertSame( 1, $this->listener->startTestCount, 'test start count failed' );
@@ -146,7 +146,7 @@ class TestListenerTest extends TestCase {
 	 * @return void
 	 */
 	public function testStartStop() {
-		$test = new Success();
+		$test = new Success( 'runTest' );
 		$test->run( $this->result );
 
 		$this->assertSame( 1, $this->listener->startTestCount, 'test start count failed' );


### PR DESCRIPTION
The `$name` parameter for the `TestCase::__construct()` method has become mandatory and should contain the name of the test method to run.

Ref: https://github.com/sebastianbergmann/phpunit/commit/705874f1b867fd99865e43cb5eaea4e6d141582f

---

This PHPUnit 10.0.0 change will generally speaking not affect "normal" users as it is rare for them to declare `__construct()` methods in test classes or to instantiate test classes directly, as this is the responsibility of PHPUnit.

In most cases, only test code testing for cross-version PHPUnit compatibility while using PHPUnit to run the tests will be affected.

Even so, fixing this is straight-forward, as the `$name` parameter was already an optional parameter since way back when, so passing the parameter in allows the tests to run (and pass) cross-version.