### PR TITLE
ExpectExceptionTest: fix PHPUnit 10.0.0 compatibility

### DIFF
--- a/tests/Polyfills/ExpectExceptionTest.php
+++ b/tests/Polyfills/ExpectExceptionTest.php
@@ -69,7 +69,7 @@ class ExpectExceptionTest extends TestCase {
 		$this->assertSame( 1, \count( $result ) );
 		$this->assertMatchesRegularExpression(
 			'`^Argument #1 \([^)]+\) of [^:]+::expectExceptionCode\(\) must be a integer or string`',
-			$test->getStatusMessage()
+			$this->getMessageContent( $test )
 		);
 	}
 
@@ -110,7 +110,7 @@ class ExpectExceptionTest extends TestCase {
 
 		$this->assertSame( 1, $result->errorCount() );
 		$this->assertSame( 1, \count( $result ) );
-		$this->assertMatchesRegularExpression( $regex, $test->getStatusMessage() );
+		$this->assertMatchesRegularExpression( $regex, $this->getMessageContent( $test ) );
 	}
 
 	/**
@@ -149,7 +149,7 @@ class ExpectExceptionTest extends TestCase {
 		$this->assertSame( 1, \count( $result ) );
 		$this->assertSame(
 			'Failed asserting that 999 is equal to expected exception code 404.',
-			$test->getStatusMessage()
+			$this->getMessageContent( $test )
 		);
 	}
 
@@ -173,7 +173,7 @@ class ExpectExceptionTest extends TestCase {
 		$this->assertSame( 1, \count( $result ) );
 		$this->assertSame(
 			"Failed asserting that exception message 'A runtime error occurred' contains 'message'.",
-			$test->getStatusMessage()
+			$this->getMessageContent( $test )
 		);
 	}
 
@@ -284,7 +284,7 @@ class ExpectExceptionTest extends TestCase {
 		$this->assertSame( 1, \count( $result ) );
 		$this->assertSame(
 			'Failed asserting that 999 is equal to expected exception code 404.',
-			$test->getStatusMessage()
+			$this->getMessageContent( $test )
 		);
 	}
 
@@ -314,7 +314,27 @@ class ExpectExceptionTest extends TestCase {
 		$this->assertSame( 1, \count( $result ) );
 		$this->assertSame(
 			"Failed asserting that exception message 'A runtime error occurred' matches '/^foo/'.",
-			$test->getStatusMessage()
+			$this->getMessageContent( $test )
 		);
+	}
+
+	/**
+	 * Helper method to retrieve the status message in a PHPUnit cross-version compatible manner.
+	 *
+	 * @param TestCase $test The test object.
+	 *
+	 * @return string
+	 */
+	private function getMessageContent( $test ) {
+		if ( \method_exists( $test, 'getStatusMessage' ) === false ) {
+			// PHPUnit >= 10.0.0.
+			return $test->status()->message();
+		}
+		else {
+			// PHPUnit < 10.0.0.
+			return $test->getStatusMessage();
+		}
+
+		return '';
 	}
 }

--- a/tests/Polyfills/ExpectExceptionTest.php
+++ b/tests/Polyfills/ExpectExceptionTest.php
@@ -5,6 +5,7 @@ namespace Yoast\PHPUnitPolyfills\Tests\Polyfills;
 use Exception;
 use PHPUnit\Framework\Exception as PHPUnit_Exception;
 use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\TestResult;
 use PHPUnit\Runner\Version as PHPUnit_Version;
 use TypeError;
 use Yoast\PHPUnitPolyfills\Polyfills\AssertionRenames;
@@ -61,7 +62,8 @@ class ExpectExceptionTest extends TestCase {
 	 */
 	public function testExpectExceptionCodeException() {
 		$test   = new InvalidExceptionCodeTestCase( 'test' );
-		$result = $test->run();
+		$result = new TestResult();
+		$test->run( $result );
 
 		$this->assertSame( 1, $result->errorCount() );
 		$this->assertSame( 1, \count( $result ) );
@@ -103,7 +105,8 @@ class ExpectExceptionTest extends TestCase {
 		}
 
 		$test   = new InvalidExceptionMessageTestCase( 'test' );
-		$result = $test->run();
+		$result = new TestResult();
+		$test->run( $result );
 
 		$this->assertSame( 1, $result->errorCount() );
 		$this->assertSame( 1, \count( $result ) );
@@ -139,7 +142,8 @@ class ExpectExceptionTest extends TestCase {
 		$test->expectExceptionMessage( 'A runtime error occurred' );
 		$test->expectExceptionCode( 404 );
 
-		$result = $test->run();
+		$result = new TestResult();
+		$test->run( $result );
 
 		$this->assertSame( 1, $result->failureCount() );
 		$this->assertSame( 1, \count( $result ) );
@@ -162,7 +166,8 @@ class ExpectExceptionTest extends TestCase {
 		$test->expectExceptionMessage( 'message' );
 		$test->expectExceptionCode( 999 );
 
-		$result = $test->run();
+		$result = new TestResult();
+		$test->run( $result );
 
 		$this->assertSame( 1, $result->failureCount() );
 		$this->assertSame( 1, \count( $result ) );
@@ -272,7 +277,8 @@ class ExpectExceptionTest extends TestCase {
 		$test->expectExceptionMessageRegExp( '/^A runtime/' );
 		$test->expectExceptionCode( 404 );
 
-		$result = $test->run();
+		$result = new TestResult();
+		$test->run( $result );
 
 		$this->assertSame( 1, $result->failureCount() );
 		$this->assertSame( 1, \count( $result ) );
@@ -301,7 +307,8 @@ class ExpectExceptionTest extends TestCase {
 		$test->expectExceptionMessageRegExp( '/^foo/' );
 		$test->expectExceptionCode( 999 );
 
-		$result = $test->run();
+		$result = new TestResult();
+		$test->run( $result );
 
 		$this->assertSame( 1, $result->failureCount() );
 		$this->assertSame( 1, \count( $result ) );


### PR DESCRIPTION
### ExpectExceptionTest: fix PHPUnit 10.0.0 compatibility [1]

... by always passing a TestResult object to the `run()` method.

The `$testResult` parameter was previously optional, but will become required as of PHPUnit 10.0.0.
Also, the `run()` method used to return an instance of `TestResult`, but will now return `void`.

Ref: sebastianbergmann/phpunit@77e6015

---

Along the same lines as 25, this PHPUnit 10.0.0 change will generally speaking not affect "normal" users.

In most cases, only test code testing for cross-version PHPUnit compatibility while using PHPUnit to run the tests will be affected.

Even so, fixing this is straight-forward, as the `$result` parameter was already an optional parameter since way back when, so instantiating the `TestResult` and passing the parameter in allows the tests to run cross-version.

### ExpectExceptionTest: fix PHPUnit 10.0.0 compatibility [2]

The `TestCase::getStatusMessage()` method has been removed in favour of `TestStatus` objects.

Ref: sebastianbergmann/phpunit@98b7c19

---

Again: this PHPUnit 10.0.0 change will generally speaking not affect "normal" users.

In most cases, only test code testing for cross-version PHPUnit compatibility while using PHPUnit to run the tests will be affected.

Fixing this requires a feature-based toggle to retrieve the status message.

