### PR TITLE
AssertClosedResource/ResourceHelper: add extra test

### DIFF
--- a/tests/Polyfills/AssertClosedResourceNotResourceTest.php
+++ b/tests/Polyfills/AssertClosedResourceNotResourceTest.php
@@ -59,6 +59,19 @@ class AssertClosedResourceNotResourceTest extends TestCase {
 	}
 
 	/**
+	 * Verify that the shouldClosedResourceAssertionBeSkipped() method returns true for non-resources.
+	 *
+	 * @dataProvider dataNotResource
+	 *
+	 * @param mixed $value The value to test.
+	 *
+	 * @return void
+	 */
+	public function testShouldClosedResourceAssertionBeSkipped( $value ) {
+		$this->assertFalse( self::shouldClosedResourceAssertionBeSkipped( $value ) );
+	}
+
+	/**
 	 * Data provider
 	 *
 	 * @return array


### PR DESCRIPTION
Add an extra test to document the behaviour of the `shouldClosedResourceAssertionBeSkipped()` method when a non-resource is passed.