### PR TITLE
GH Actions: no need to lint twice

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -91,11 +91,11 @@ jobs:
           composer-options: --ignore-platform-reqs
 
       - name: "Lint PHP files against parse errors - PHP < 7.0"
-        if: ${{ matrix.php < 7.0 }}
+        if: ${{ matrix.phpunit == 'auto' && matrix.php < 7.0 }}
         run: composer lint-lt71
 
       - name: "Lint PHP files against parse errors - PHP >= 7.0"
-        if: ${{ matrix.php >= 7.0 }}
+        if: ${{ matrix.phpunit == 'auto' && matrix.php >= 7.0 }}
         run: composer lint
 
       - name: Run the unit tests


### PR DESCRIPTION
With the matrix now expanded, linting would now be done multiple times per PHP version, which isn't really necessary.