### PR TITLE
Add polyfills for the PHP 7.0 `TypeError` and `Error` classes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -92,11 +92,15 @@ jobs:
 
       - name: "Lint PHP files against parse errors - PHP < 7.0"
         if: ${{ matrix.phpunit == 'auto' && matrix.php < 7.0 }}
-        run: composer lint-lt71
+        run: composer lint-lt70
 
-      - name: "Lint PHP files against parse errors - PHP >= 7.0"
-        if: ${{ matrix.phpunit == 'auto' && matrix.php >= 7.0 }}
-        run: composer lint
+      - name: "Lint PHP files against parse errors - PHP 7.x"
+        if: ${{ matrix.phpunit == 'auto' && startsWith( matrix.php, '7' ) }}
+        run: composer lint7
+
+      - name: "Lint PHP files against parse errors - PHP >= 8.0"
+        if: ${{ matrix.phpunit == 'auto' && matrix.php >= 8.0 }}
+        run: composer lint-gte80
 
       - name: Run the unit tests
         run: composer test

--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -50,6 +50,10 @@
 		<exclude name="WordPress.Security"/>
 		<exclude name="WordPress.WP"/>
 		<exclude name="Yoast.Yoast.AlternativeFunctions"/>
+
+		<!-- These PHP 7.0+ classes are polyfilled for this repo. -->
+		<exclude name="PHPCompatibility.Classes.NewClasses.errorFound"/>
+		<exclude name="PHPCompatibility.Classes.NewClasses.typeerrorFound"/>
 	</rule>
 
 	<!-- Enforce PSR1 compatible namespaces. -->
@@ -80,6 +84,13 @@
 	Exclude specific files for specific sniffs and/or exclude sub-groups in sniffs.
 	#############################################################################
 	-->
+
+	<!-- The polyfills for the PHP native exceptions can not have a namespace
+		 and making those the only files with a file comment would create more,
+		 not less inconsistency. -->
+	<rule ref="Yoast.Commenting.FileComment">
+		<exclude-pattern>/src/Exceptions/*Error\.php$</exclude-pattern>
+	</rule>
 
 	<!-- Deliberately empty Catch statements. -->
 	<rule ref="Generic.CodeAnalysis.EmptyStatement.DetectedCatch">

--- a/composer.json
+++ b/composer.json
@@ -46,11 +46,14 @@
         }
     },
     "scripts": {
-        "lint": [
-            "@php ./vendor/php-parallel-lint/php-parallel-lint/parallel-lint . -e php --exclude vendor --exclude .git"
+        "lint7": [
+            "@php ./vendor/php-parallel-lint/php-parallel-lint/parallel-lint . -e php --exclude vendor --exclude .git --exclude src/Exceptions/Error.php --exclude src/Exceptions/TypeError.php"
         ],
-        "lint-lt71": [
+        "lint-lt70": [
             "@php ./vendor/php-parallel-lint/php-parallel-lint/parallel-lint . -e php --exclude vendor --exclude .git --exclude src/TestCases/TestCasePHPUnitGte8.php --exclude src/TestListeners/TestListenerDefaultImplementationPHPUnitGte7.php"
+        ],
+        "lint-gte80": [
+            "@php ./vendor/php-parallel-lint/php-parallel-lint/parallel-lint . -e php --exclude vendor --exclude .git"
         ],
         "check-cs": [
             "@php ./vendor/squizlabs/php_codesniffer/bin/phpcs --runtime-set testVersion 5.4-"

--- a/phpunitpolyfills-autoload.php
+++ b/phpunitpolyfills-autoload.php
@@ -19,6 +19,27 @@ if ( \class_exists( 'Yoast\PHPUnitPolyfills\Autoload', false ) === false ) {
 		 * @return bool
 		 */
 		public static function load( $className ) {
+			/*
+			 * Polyfill two PHP 7.0 classes.
+			 * The autoloader will only be called for these if these classes don't already
+			 * exist in PHP natively.
+			 */
+			if ( $className === 'Error' || $className === 'TypeError' ) {
+				$file = \realpath(
+					__DIR__ . \DIRECTORY_SEPARATOR
+					. 'src' . \DIRECTORY_SEPARATOR
+					. 'Exceptions' . \DIRECTORY_SEPARATOR
+					. $className . '.php'
+				);
+
+				if ( \file_exists( $file ) === true ) {
+					require_once $file;
+					return true;
+				}
+
+				return false;
+			}
+
 			// Only load classes belonging to this library.
 			if ( \stripos( $className, 'Yoast\PHPUnitPolyfills' ) !== 0 ) {
 				return false;

--- a/src/Exceptions/Error.php
+++ b/src/Exceptions/Error.php
@@ -1,0 +1,8 @@
+<?php
+
+/**
+ * Polyfill the PHP 7.0+ native Error class.
+ *
+ * @phpcs:disable PSR1.Classes.ClassDeclaration.MissingNamespace
+ */
+class Error extends Exception {}

--- a/src/Exceptions/TypeError.php
+++ b/src/Exceptions/TypeError.php
@@ -1,0 +1,8 @@
+<?php
+
+/**
+ * Polyfill the PHP 7.0+ native TypeError class.
+ *
+ * @phpcs:disable PSR1.Classes.ClassDeclaration.MissingNamespace
+ */
+class TypeError extends Error {}


### PR DESCRIPTION
Some of the existing code already references these classes and while not (currently) done in a PHP cross-version problematic way, it is still better to make sure these classes exist for optimal PHP cross-version compatibility.

While not strictly correct/PSR4-compliant, I've elected to put these classes in the `Exceptions` subfolder, even though these are non-namespaced classes and not strictly part of the _PHPUnit_ polyfills.

Note: the autoloader will only be called if these classes do not exist in PHP itself (PHP < 7.0), so the way it is set up now, these files will never get loaded on PHP >= 7.0 (which would otherwise cause a "Class already declared" error).

Includes:
* Explicitly excluding the PHPCompatibility notices about these classes in the PHPCS ruleset.
    _Note: due to the use of the PHPCompatibilityWP ruleset in YoastCS, these notices weren't showing anyway as WP backfills these classes. All the same, making it explicit in the ruleset documents the polyfills as now included in this repo._
* Adjustments to the Composer scripts to run the PHP linting and the GH Actions workflow which runs it.
    On PHP 7.x, these polyfills would cause a `Cannot declare class Error, because the name is already in use in ...` error otherwise.