### PR TITLE
PHPCS: use PHPCompatibility proper, not PHPCompatibilityWP

### DIFF
--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -50,6 +50,14 @@
 		<exclude name="WordPress.Security"/>
 		<exclude name="WordPress.WP"/>
 		<exclude name="Yoast.Yoast.AlternativeFunctions"/>
+	</rule>
+
+	<!-- While PHPCompatibility is already included in the Yoast ruleset, it uses
+		 the PHPCompatibilityWP ruleset, which excludes rules polyfilled by WP.
+		 Setting the severity for all PHPCompatibility rules to 5 prevents WP
+		 polyfilled functionality from not being flagged in this repo. -->
+	<rule ref="PHPCompatibility">
+		<severity>5</severity>
 
 		<!-- These PHP 7.0+ classes are polyfilled for this repo. -->
 		<exclude name="PHPCompatibility.Classes.NewClasses.errorFound"/>

--- a/src/Polyfills/AssertIsType.php
+++ b/src/Polyfills/AssertIsType.php
@@ -155,6 +155,7 @@ trait AssertIsType {
 	public static function assertIsIterable( $actual, $message = '' ) {
 		if ( \function_exists( 'is_iterable' ) === true ) {
 			// PHP >= 7.1.
+			// phpcs:ignore PHPCompatibility.FunctionUse.NewFunctions.is_iterableFound
 			static::assertTrue( \is_iterable( $actual ), $message );
 		}
 		else {
@@ -302,6 +303,7 @@ trait AssertIsType {
 	public static function assertIsNotIterable( $actual, $message = '' ) {
 		if ( \function_exists( 'is_iterable' ) === true ) {
 			// PHP >= 7.1.
+			// phpcs:ignore PHPCompatibility.FunctionUse.NewFunctions.is_iterableFound
 			static::assertFalse( \is_iterable( $actual ), $message );
 		}
 		else {


### PR DESCRIPTION
When adding the `TypeError`/`Error` polyfill (#36), I suddenly realized that the use of the `PHPCompatibilityWP` ruleset by the `Yoast` standard was causing certain issues not to show up, while - for this repo - they **_should_** be shown.

By setting the `severity` of all the sniffs in the `PHPCompatibilility` ruleset back to `5`, the `exclude`s from the `PHPCompatibilityWP` ruleset are effectively "undone" and we are back to using `PHPCompatibility` proper.