### PR TITLE
GH Actions: selectively don't mark PRs as failed

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -104,4 +104,10 @@ jobs:
         run: composer lint-gte80
 
       - name: Run the unit tests
+        if: ${{ matrix.phpunit != '^10.0' }}
+        run: composer test
+
+      - name: Trial run the unit tests against PHPUnit 10.0
+        if: ${{ matrix.phpunit == '^10.0' }}
+        continue-on-error: true
         run: composer test


### PR DESCRIPTION
When a `job` has builds which are allowed to `continue-on-error` and only those fail/error, the workflow will be marked as "passed" (green), but for any PR containing builds which failed, even though they are allowed to fail, the PR will still show an :x:.

This is confusing and discouraging for people.

Currently, there are two builds which are "allowed to fail":
* A build against PHP 8.1.
* A build against PHPUnit 10.

As people are starting to test against PHP 8.1, if that build would start to fail, it needs to be looked at straight away.

However, as PHPUnit 10.0 is still under heavy development and a release is still a while away, let's not let PRs be marked as failed, when that is the only build which is failing.