### PR TITLE
Composer: update dev dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
         "phpunit/phpunit": "^4.8.36 || ^5.7.21 || ^6.0 || ^7.0 || ^8.0 || ^9.0"
     },
     "require-dev": {
-        "php-parallel-lint/php-parallel-lint": "^1.3.0",
+        "php-parallel-lint/php-parallel-lint": "^1.3.1",
         "php-parallel-lint/php-console-highlighter": "^0.5",
         "yoast/yoastcs": "^2.1.0"
     },


### PR DESCRIPTION
Most notably, PHP Parallel Lint 1.3.1 has improved compatibility with PHP 8.1.

Refs:
* https://github.com/php-parallel-lint/PHP-Parallel-Lint/releases/tag/v1.3.1