### PR TITLE
Update for YoastCS 2.2.0

### DIFF
--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -50,6 +50,7 @@
 		<exclude name="WordPress.Security"/>
 		<exclude name="WordPress.WP"/>
 		<exclude name="Yoast.Yoast.AlternativeFunctions"/>
+		<exclude name="Yoast.NamingConventions.ObjectNameDepth.MaxExceeded"/>
 	</rule>
 
 	<!-- While PHPCompatibility is already included in the Yoast ruleset, it uses
@@ -143,6 +144,7 @@
 	<!-- Covers annotations are in the test classes, not the trait. -->
 	<rule ref="Yoast.Commenting.TestsHaveCoversTag.Missing">
 		<exclude-pattern>/tests/TestCases/TestCaseTestTrait\.php$</exclude-pattern>
+		<exclude-pattern>/tests/Polyfills/Fixtures/*\.php$</exclude-pattern>
 	</rule>
 
 	<!-- These fixtures for the assertEqualObject() tests will only be loaded on PHP 7+/8+ respectively. -->

--- a/composer.json
+++ b/composer.json
@@ -27,9 +27,7 @@
         "phpunit/phpunit": "^4.8.36 || ^5.7.21 || ^6.0 || ^7.0 || ^8.0 || ^9.0"
     },
     "require-dev": {
-        "php-parallel-lint/php-parallel-lint": "^1.3.1",
-        "php-parallel-lint/php-console-highlighter": "^0.5",
-        "yoast/yoastcs": "^2.1.0"
+        "yoast/yoastcs": "^2.2.0"
     },
     "autoload": {
         "files": ["phpunitpolyfills-autoload.php"]


### PR DESCRIPTION
### Composer: update to YoastCS 2.2.0

... which includes PHP Parallel Lint by design, so no need to require it separately anymore.

Ref: https://github.com/Yoast/yoastcs/releases

### PHPCS: minor tweaks to the ruleset

* For camelCase object names which are not going to be changed being flagged.
* For fixtures containing test methods being flagged. Those are not the real tests.

