### PR TITLE
GH Actions: adjust matrix - add PHP 8.2, PHP 8.1 not allowed to fail

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,6 +51,10 @@ jobs:
             experimental: false
 
           # Experimental builds.
+          - php: '8.2'
+            phpunit: 'auto'
+            experimental: true
+
           - php: '8.0'
             phpunit: '^10.0'
             experimental: true
@@ -76,13 +80,13 @@ jobs:
 
       # Install dependencies and handle caching in one go.
       # @link https://github.com/marketplace/actions/install-composer-dependencies
-      - name: Install Composer dependencies for PHP < 8.1
-        if: ${{ matrix.php < 8.1 }}
+      - name: Install Composer dependencies for PHP < 8.2
+        if: ${{ matrix.php < 8.2 }}
         uses: "ramsey/composer-install@v1"
 
-      # For PHP 8.1 and above, we need to install with ignore platform reqs as not all dependencies allow it yet.
-      - name: Install Composer dependencies for PHP >= 8.1
-        if: ${{ matrix.php >= 8.1 }}
+      # For PHP 8.2 and above, we need to install with ignore platform reqs as not all dependencies allow it yet.
+      - name: Install Composer dependencies for PHP >= 8.2
+        if: ${{ matrix.php >= 8.2 }}
         uses: "ramsey/composer-install@v1"
         with:
           composer-options: --ignore-platform-reqs

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
 
     strategy:
       matrix:
-        php: ['5.4', '5.5', '5.6', '7.0', '7.1', '7.2', '7.3', '7.4', '8.0']
+        php: ['5.4', '5.5', '5.6', '7.0', '7.1', '7.2', '7.3', '7.4', '8.0', '8.1']
         phpunit: ['auto']
         experimental: [false]
 
@@ -51,10 +51,6 @@ jobs:
             experimental: false
 
           # Experimental builds.
-          - php: '8.1'
-            phpunit: 'auto'
-            experimental: true
-
           - php: '8.0'
             phpunit: '^10.0'
             experimental: true


### PR DESCRIPTION
### GH Actions: build against PHP 8.1 is no longer allowed to fail

The build against PHP 8.1 has been passing for a while and it should stay that way.

### GH Actions: start testing against PHP 8.2

... but allow for the builds to fail.