### PR TITLE
Autoload: improve/stabilize version check for TestCase

### DIFF
--- a/phpunitpolyfills-autoload.php
+++ b/phpunitpolyfills-autoload.php
@@ -3,6 +3,7 @@
 namespace Yoast\PHPUnitPolyfills;
 
 use PHPUnit\Runner\Version as PHPUnit_Version;
+use PHPUnit_Runner_Version;
 
 if ( \class_exists( 'Yoast\PHPUnitPolyfills\Autoload', false ) === false ) {
 
@@ -426,9 +427,7 @@ if ( \class_exists( 'Yoast\PHPUnitPolyfills\Autoload', false ) === false ) {
 		 * @return void
 		 */
 		public static function loadTestCase() {
-			if ( \class_exists( '\PHPUnit_Runner_Version' ) === true
-				|| \version_compare( PHPUnit_Version::id(), '8.0.0', '<' )
-			) {
+			if ( \version_compare( self::getPHPUnitVersion(), '8.0.0', '<' ) ) {
 				// PHPUnit < 8.0.0.
 				require_once __DIR__ . '/src/TestCases/TestCasePHPUnitLte7.php';
 				return;
@@ -444,7 +443,7 @@ if ( \class_exists( 'Yoast\PHPUnitPolyfills\Autoload', false ) === false ) {
 		 * @return void
 		 */
 		public static function loadTestListenerDefaultImplementation() {
-			if ( \class_exists( '\PHPUnit_Runner_Version' ) === true ) {
+			if ( \version_compare( self::getPHPUnitVersion(), '6.0.0', '<' ) ) {
 				/*
 				 * Alias one particular PHPUnit 4/5 class to its PHPUnit >= 6 name.
 				 *
@@ -473,6 +472,26 @@ if ( \class_exists( 'Yoast\PHPUnitPolyfills\Autoload', false ) === false ) {
 
 			// PHPUnit >= 7.0.0.
 			require_once __DIR__ . '/src/TestListeners/TestListenerDefaultImplementationPHPUnitGte7.php';
+		}
+
+		/**
+		 * Retrieve the PHPUnit version id.
+		 *
+		 * As both the pre-PHPUnit 6 class, as well as the PHPUnit 6+ class contain the `id()` function,
+		 * this should work independently of whether or not another library may have aliased the class.
+		 *
+		 * @return string Version number as a string.
+		 */
+		public static function getPHPUnitVersion() {
+			if ( \class_exists( '\PHPUnit\Runner\Version' ) ) {
+				return PHPUnit_Version::id();
+			}
+
+			if ( \class_exists( '\PHPUnit_Runner_Version' ) ) {
+				return PHPUnit_Runner_Version::id();
+			}
+
+			return '0';
 		}
 	}
 


### PR DESCRIPTION
The version check in the `Autoload::loadTestCase()` method could get confused if the package using this library, or a dependency of the package using this library would alias the `PHPUnit_Runner_Version`/`PHPUnit\Runner\Version` class.

As both classes contain the method we need to retrieve the version number, let's always base the loading on the available PHPUnit version number instead of the availability of either class.