### PR TITLE
Release version 1.0.2

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
 
     strategy:
       matrix:
-        php: ['5.4', '5.5', '5.6', '7.0', '7.1', '7.2', '7.3', '7.4', '8.0']
+        php: ['5.4', '5.5', '5.6', '7.0', '7.1', '7.2', '7.3', '7.4', '8.0', '8.1']
         phpunit: ['auto']
         experimental: [false]
 
@@ -51,7 +51,7 @@ jobs:
             experimental: false
 
           # Experimental builds.
-          - php: '8.1'
+          - php: '8.2'
             phpunit: 'auto'
             experimental: true
 
@@ -80,13 +80,13 @@ jobs:
 
       # Install dependencies and handle caching in one go.
       # @link https://github.com/marketplace/actions/install-composer-dependencies
-      - name: Install Composer dependencies for PHP < 8.1
-        if: ${{ matrix.php < 8.1 }}
+      - name: Install Composer dependencies for PHP < 8.2
+        if: ${{ matrix.php < 8.2 }}
         uses: "ramsey/composer-install@v1"
 
-      # For PHP 8.1 and above, we need to install with ignore platform reqs as not all dependencies allow it yet.
-      - name: Install Composer dependencies for PHP >= 8.1
-        if: ${{ matrix.php >= 8.1 }}
+      # For PHP 8.2 and above, we need to install with ignore platform reqs as not all dependencies allow it yet.
+      - name: Install Composer dependencies for PHP >= 8.2
+        if: ${{ matrix.php >= 8.2 }}
         uses: "ramsey/composer-install@v1"
         with:
           composer-options: --ignore-platform-reqs

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -104,4 +104,10 @@ jobs:
         run: composer lint-gte80
 
       - name: Run the unit tests
+        if: ${{ matrix.phpunit != '^10.0' }}
+        run: composer test
+
+      - name: Trial run the unit tests against PHPUnit 10.0
+        if: ${{ matrix.phpunit == '^10.0' }}
+        continue-on-error: true
         run: composer test

--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -50,6 +50,7 @@
 		<exclude name="WordPress.Security"/>
 		<exclude name="WordPress.WP"/>
 		<exclude name="Yoast.Yoast.AlternativeFunctions"/>
+		<exclude name="Yoast.NamingConventions.ObjectNameDepth.MaxExceeded"/>
 	</rule>
 
 	<!-- While PHPCompatibility is already included in the Yoast ruleset, it uses
@@ -143,6 +144,7 @@
 	<!-- Covers annotations are in the test classes, not the trait. -->
 	<rule ref="Yoast.Commenting.TestsHaveCoversTag.Missing">
 		<exclude-pattern>/tests/TestCases/TestCaseTestTrait\.php$</exclude-pattern>
+		<exclude-pattern>/tests/Polyfills/Fixtures/*\.php$</exclude-pattern>
 	</rule>
 
 	<!-- These fixtures for the assertEqualObject() tests will only be loaded on PHP 7+/8+ respectively. -->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,25 @@ This projects adheres to [Keep a CHANGELOG](http://keepachangelog.com/) and uses
 
 _Nothing yet._
 
+## [1.0.2] - 2021-10-03
+
+As of version 2.15.0 of the `shivammathur/setup-php` action for GitHub Actions, the PHPUnit Polyfills can be installed directly from this action using the `tools` key.
+
+### Added
+* README: FAQ section about installing and using the library via the `shivammathur/setup-php` action. PR [#52]
+
+### Changed
+* README: minor textual clarifications and improvements. PRs [#52], [$54], props [Pierre Gordon].
+* General housekeeping.
+
+### Fixed
+* Autoloader: improved compatibility with packages which create a `class_alias` for the `PHPUnit_Runner_Version` or `PHPUnit\Runner\Version` class. PR [#59]
+
+[#52]: https://github.com/Yoast/PHPUnit-Polyfills/pull/52
+[#54]: https://github.com/Yoast/PHPUnit-Polyfills/pull/54
+[#59]: https://github.com/Yoast/PHPUnit-Polyfills/pull/59
+
+
 ## [1.0.1] - 2021-08-09
 
 ### Added
@@ -81,6 +100,7 @@ Initial release.
 
 
 [Unreleased]: https://github.com/Yoast/PHPUnit-Polyfills/compare/main...HEAD
+[1.0.2]: https://github.com/Yoast/PHPUnit-Polyfills/compare/1.0.1...1.0.2
 [1.0.1]: https://github.com/Yoast/PHPUnit-Polyfills/compare/1.0.0...1.0.1
 [1.0.0]: https://github.com/Yoast/PHPUnit-Polyfills/compare/0.2.0...1.0.0
 [0.2.0]: https://github.com/Yoast/PHPUnit-Polyfills/compare/0.1.0...0.2.0
@@ -90,3 +110,5 @@ Initial release.
 [Marc Siegrist]: https://github.com/mergeMarc
 [Mark Baker]: https://github.com/MarkBaker
 [Pascal Birchler]: https://github.com/swissspidy
+[Pierre Gordon]: https://github.com/pierlon
+

--- a/README.md
+++ b/README.md
@@ -711,7 +711,7 @@ After this step has run, you can run PHPUnit, like you would normally, by using 
   run: phpunit
 ```
 
-:point_right: If you rely on Composer for autoloading your project files, you will still need to run `composer autoload --dev` and include the project local `vendor/autoload.php` file as/in your test bootstrap.
+:point_right: If you rely on Composer for autoloading your project files, you will still need to run `composer dump-autoload --dev` and include the project local `vendor/autoload.php` file as/in your test bootstrap.
 
 > :mortar_board: Why this works:
 >

--- a/composer.json
+++ b/composer.json
@@ -27,9 +27,7 @@
         "phpunit/phpunit": "^4.8.36 || ^5.7.21 || ^6.0 || ^7.0 || ^8.0 || ^9.0"
     },
     "require-dev": {
-        "php-parallel-lint/php-parallel-lint": "^1.3.1",
-        "php-parallel-lint/php-console-highlighter": "^0.5",
-        "yoast/yoastcs": "^2.1.0"
+        "yoast/yoastcs": "^2.2.0"
     },
     "autoload": {
         "files": ["phpunitpolyfills-autoload.php"]

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
         "phpunit/phpunit": "^4.8.36 || ^5.7.21 || ^6.0 || ^7.0 || ^8.0 || ^9.0"
     },
     "require-dev": {
-        "php-parallel-lint/php-parallel-lint": "^1.3.0",
+        "php-parallel-lint/php-parallel-lint": "^1.3.1",
         "php-parallel-lint/php-console-highlighter": "^0.5",
         "yoast/yoastcs": "^2.1.0"
     },

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -6,6 +6,7 @@
     bootstrap="./tests/bootstrap.php"
     beStrictAboutTestsThatDoNotTestAnything="true"
     colors="true"
+    convertDeprecationsToExceptions="true"
     forceCoversAnnotation="true">
 
     <testsuites>

--- a/phpunitpolyfills-autoload.php
+++ b/phpunitpolyfills-autoload.php
@@ -3,6 +3,7 @@
 namespace Yoast\PHPUnitPolyfills;
 
 use PHPUnit\Runner\Version as PHPUnit_Version;
+use PHPUnit_Runner_Version;
 
 if ( \class_exists( 'Yoast\PHPUnitPolyfills\Autoload', false ) === false ) {
 
@@ -426,9 +427,7 @@ if ( \class_exists( 'Yoast\PHPUnitPolyfills\Autoload', false ) === false ) {
 		 * @return void
 		 */
 		public static function loadTestCase() {
-			if ( \class_exists( '\PHPUnit_Runner_Version' ) === true
-				|| \version_compare( PHPUnit_Version::id(), '8.0.0', '<' )
-			) {
+			if ( \version_compare( self::getPHPUnitVersion(), '8.0.0', '<' ) ) {
 				// PHPUnit < 8.0.0.
 				require_once __DIR__ . '/src/TestCases/TestCasePHPUnitLte7.php';
 				return;
@@ -444,7 +443,7 @@ if ( \class_exists( 'Yoast\PHPUnitPolyfills\Autoload', false ) === false ) {
 		 * @return void
 		 */
 		public static function loadTestListenerDefaultImplementation() {
-			if ( \class_exists( '\PHPUnit_Runner_Version' ) === true ) {
+			if ( \version_compare( self::getPHPUnitVersion(), '6.0.0', '<' ) ) {
 				/*
 				 * Alias one particular PHPUnit 4/5 class to its PHPUnit >= 6 name.
 				 *
@@ -473,6 +472,26 @@ if ( \class_exists( 'Yoast\PHPUnitPolyfills\Autoload', false ) === false ) {
 
 			// PHPUnit >= 7.0.0.
 			require_once __DIR__ . '/src/TestListeners/TestListenerDefaultImplementationPHPUnitGte7.php';
+		}
+
+		/**
+		 * Retrieve the PHPUnit version id.
+		 *
+		 * As both the pre-PHPUnit 6 class, as well as the PHPUnit 6+ class contain the `id()` function,
+		 * this should work independently of whether or not another library may have aliased the class.
+		 *
+		 * @return string Version number as a string.
+		 */
+		public static function getPHPUnitVersion() {
+			if ( \class_exists( '\PHPUnit\Runner\Version' ) ) {
+				return PHPUnit_Version::id();
+			}
+
+			if ( \class_exists( '\PHPUnit_Runner_Version' ) ) {
+				return PHPUnit_Runner_Version::id();
+			}
+
+			return '0';
 		}
 	}
 

--- a/phpunitpolyfills-autoload.php
+++ b/phpunitpolyfills-autoload.php
@@ -17,7 +17,7 @@ if ( \class_exists( 'Yoast\PHPUnitPolyfills\Autoload', false ) === false ) {
 		 *
 		 * @var string
 		 */
-		const VERSION = '1.0.1';
+		const VERSION = '1.0.2';
 
 		/**
 		 * Loads a class.


### PR DESCRIPTION
### Functional:
- [x] Confirm that the most recent PHPUnit changelogs have been checked and that the library is still feature complete for those versions supported within the PHPUnit version constraints.
- [x] Update the `VERSION` constant in the `phpunitpolyfills-autoload.php` file. PR #60
- [x] Composer: check if any dependencies/version constraints need updating.

### Release:
- [x] Add changelog for the release - PR #60
    Verify that a release link at the bottom of the `CHANGELOG.md` file has been added.
- [ ] Merge this PR.
- [ ] Make sure all CI builds are green.
- [ ] Tag the release (careful, GH defaults to `develop`!).
- [ ] Create a release from the tag (careful, GH defaults to `develop`!) & copy & paste the changelog to it.
    Make sure to copy the links to the issues and the links to the GH usernames from the bottom of the changelog!
- [ ] Close the milestone.
- [ ] Open a new milestone for the next release.
- [ ] If any open PRs/issues which were milestoned for the release did not make it into the release, update their milestone.

### Announce:
- [ ] Tweet about the release.