### PR TITLE
GH Actions: various improvements

### DIFF
--- a/.github/workflows/cs.yml
+++ b/.github/workflows/cs.yml
@@ -7,6 +7,12 @@ on:
   # Allow manually triggering the workflow.
   workflow_dispatch:
 
+# Cancels all previous workflow runs for the same branch that have not yet completed.
+concurrency:
+  # The concurrency group contains the workflow name and the branch name.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   checkcs:
     name: 'Basic CS and QA checks'

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,6 +7,12 @@ on:
   # Allow manually triggering the workflow.
   workflow_dispatch:
 
+# Cancels all previous workflow runs for the same branch that have not yet completed.
+concurrency:
+  # The concurrency group contains the workflow name and the branch name.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   #### PHP Code Linting ####
   lint:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,52 @@
+name: Lint
+
+on:
+  # Run on all pushes and on all pull requests.
+  push:
+  pull_request:
+  # Allow manually triggering the workflow.
+  workflow_dispatch:
+
+jobs:
+  #### PHP Code Linting ####
+  lint:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        php: ['5.4', '5.5', '5.6', '7.0', '7.1', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2']
+
+    name: "Lint: PHP ${{ matrix.php }}"
+
+    continue-on-error: ${{ matrix.php == '8.2' }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Install PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          ini-values: zend.assertions=1, error_reporting=-1, display_errors=On
+          coverage: none
+
+      - name: 'Composer: remove PHPUnit (not needed for lint)'
+        run: composer remove phpunit/phpunit --no-update
+
+      # Install dependencies and handle caching in one go.
+      # @link https://github.com/marketplace/actions/install-composer-dependencies
+      - name: Install Composer dependencies
+        uses: "ramsey/composer-install@v1"
+
+      - name: "Lint PHP files against parse errors - PHP < 7.0"
+        if: ${{ matrix.php < 7.0 }}
+        run: composer lint-lt70
+
+      - name: "Lint PHP files against parse errors - PHP 7.x"
+        if: ${{ startsWith( matrix.php, '7' ) }}
+        run: composer lint7
+
+      - name: "Lint PHP files against parse errors - PHP >= 8.0"
+        if: ${{ matrix.php >= 8.0 }}
+        run: composer lint-gte80

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -91,18 +91,6 @@ jobs:
         with:
           composer-options: --ignore-platform-reqs
 
-      - name: "Lint PHP files against parse errors - PHP < 7.0"
-        if: ${{ matrix.phpunit == 'auto' && matrix.php < 7.0 }}
-        run: composer lint-lt70
-
-      - name: "Lint PHP files against parse errors - PHP 7.x"
-        if: ${{ matrix.phpunit == 'auto' && startsWith( matrix.php, '7' ) }}
-        run: composer lint7
-
-      - name: "Lint PHP files against parse errors - PHP >= 8.0"
-        if: ${{ matrix.phpunit == 'auto' && matrix.php >= 8.0 }}
-        run: composer lint-gte80
-
       - name: Run the unit tests
         if: ${{ matrix.phpunit != '^10.0' }}
         run: composer test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,6 +7,12 @@ on:
   # Allow manually triggering the workflow.
   workflow_dispatch:
 
+# Cancels all previous workflow runs for the same branch that have not yet completed.
+concurrency:
+  # The concurrency group contains the workflow name and the branch name.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   #### TEST STAGE ####
   test:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -71,7 +71,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
-          ini-values: error_reporting=E_ALL, display_errors=On
+          ini-values: zend.assertions=1, error_reporting=-1, display_errors=On
           coverage: none
 
       - name: 'Composer: set PHPUnit version for tests'

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@ PHPUnit Polyfills
 
 [![Version](https://poser.pugx.org/yoast/phpunit-polyfills/version)](//packagist.org/packages/yoast/phpunit-polyfills)
 [![CS Build Status](https://github.com/Yoast/PHPUnit-Polyfills/actions/workflows/cs.yml/badge.svg)](https://github.com/Yoast/PHPUnit-Polyfills/actions/workflows/cs.yml)
+[![Lint Build Status](https://github.com/Yoast/PHPUnit-Polyfills/actions/workflows/lint.yml/badge.svg)](https://github.com/Yoast/PHPUnit-Polyfills/actions/workflows/lint.yml)
 [![Test Build Status](https://github.com/Yoast/PHPUnit-Polyfills/actions/workflows/test.yml/badge.svg)](https://github.com/Yoast/PHPUnit-Polyfills/actions/workflows/test.yml)
 [![Minimum PHP Version](https://img.shields.io/packagist/php-v/yoast/phpunit-polyfills.svg?maxAge=3600)](https://packagist.org/packages/yoast/phpunit-polyfills)
 [![License: BSD3](https://poser.pugx.org/yoast/phpunit-polyfills/license)](https://github.com/Yoast/PHPUnit-Polyfills/blob/master/LICENSE)


### PR DESCRIPTION
### GH Actions: split off lint workflow

Execute linting in a separate workflow from running the tests.

### GH Actions: further improve PHP ini settings

* `E_ALL` does not really contain **ALL** PHP notices across all PHP versions, in some `E_STRICT`, for instance, is excluded from `E_ALL`, so using `-1` is the better choice as that will always contain everything.
* While assertions are (as far as I'm aware) not currently used in the code base, it's still a good idea to enable `zend_assertions` in case something would be changed in the test tooling used.
    This is one of the other ini settings which is not turned on by default in the `setup-php` action.
    Ref: https://www.php.net/manual/en/ini.core.php#ini.zend.assertions

### GH Actions: auto-cancel previous builds for same branch

In Travis, when the same branch was pushed again and the "Auto cancellation" option on the "Settings" page had been turned on (as it was for most repos), any still running builds for the same branch would be stopped in favour of starting the build for the newly pushed version of the branch.

To enable this behaviour in GH Actions, a `concurrency` configuration needs to be added to each workflow for which this should applied to.

More than anything, this is a way to be kind to GitHub by not wasting resources which they so kindly provide to us for free.

Refs:
* https://github.blog/changelog/2021-04-19-github-actions-limit-workflow-run-or-job-concurrency/
* https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions#concurrency