### PR TITLE
Tests: tweaks for PHPUnit 10.x compatibility

### DIFF
--- a/tests/TestListeners/Fixtures/FailurePHPUnitGte7.php
+++ b/tests/TestListeners/Fixtures/FailurePHPUnitGte7.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Yoast\PHPUnitPolyfills\Tests\TestListeners\Fixtures;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Fixture to generate a "failed test" to pass to the test listener.
+ *
+ * @requires PHPUnit 7.0
+ */
+class FailurePHPUnitGte7 extends TestCase {
+
+	/**
+	 * Test resulting in a failed test.
+	 *
+	 * @return void
+	 */
+	protected function testForListener() {
+		$this->fail();
+	}
+}

--- a/tests/TestListeners/Fixtures/IncompletePHPUnitGte7.php
+++ b/tests/TestListeners/Fixtures/IncompletePHPUnitGte7.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Yoast\PHPUnitPolyfills\Tests\TestListeners\Fixtures;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Fixture to generate an "incomplete test" to pass to the test listener.
+ *
+ * @requires PHPUnit 7.0
+ */
+class IncompletePHPUnitGte7 extends TestCase {
+
+	/**
+	 * Test resulting in a test marked as incomplete.
+	 *
+	 * @return void
+	 */
+	protected function testForListener() {
+		$this->markTestIncomplete( 'Test incomplete' );
+	}
+}

--- a/tests/TestListeners/Fixtures/RiskyPHPUnitGte7.php
+++ b/tests/TestListeners/Fixtures/RiskyPHPUnitGte7.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Yoast\PHPUnitPolyfills\Tests\TestListeners\Fixtures;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Fixture to generate a "risky test" to pass to the test listener.
+ *
+ * @requires PHPUnit 7.0
+ */
+class RiskyPHPUnitGte7 extends TestCase {
+
+	/**
+	 * Test resulting in a test marked as risky.
+	 *
+	 * @return void
+	 */
+	protected function testForListener() {
+		$this->markAsRisky();
+	}
+}

--- a/tests/TestListeners/Fixtures/SkippedPHPUnitGte7.php
+++ b/tests/TestListeners/Fixtures/SkippedPHPUnitGte7.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Yoast\PHPUnitPolyfills\Tests\TestListeners\Fixtures;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Fixture to generate a "skipped test" to pass to the test listener.
+ *
+ * @requires PHPUnit 7.0
+ */
+class SkippedPHPUnitGte7 extends TestCase {
+
+	/**
+	 * Test resulting in a test marked as skipped.
+	 *
+	 * @return void
+	 */
+	protected function testForListener() {
+		$this->markTestSkipped( 'Skipped test' );
+	}
+}

--- a/tests/TestListeners/Fixtures/SuccessPHPUnitGte7.php
+++ b/tests/TestListeners/Fixtures/SuccessPHPUnitGte7.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Yoast\PHPUnitPolyfills\Tests\TestListeners\Fixtures;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Fixture to generate a "successfull test" to pass to the test listener.
+ *
+ * @requires PHPUnit 7.0
+ */
+class SuccessPHPUnitGte7 extends TestCase {
+
+	/**
+	 * Test resulting in a successfull test.
+	 *
+	 * @return void
+	 */
+	protected function testForListener() {
+		$this->assertTrue( true );
+	}
+}

--- a/tests/TestListeners/Fixtures/TestErrorPHPUnitGte7.php
+++ b/tests/TestListeners/Fixtures/TestErrorPHPUnitGte7.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Yoast\PHPUnitPolyfills\Tests\TestListeners\Fixtures;
+
+use Exception;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Fixture to generate a test error to pass to the test listener.
+ *
+ * @requires PHPUnit 7.0
+ *
+ * @coversNothing
+ */
+class TestErrorPHPUnitGte7 extends TestCase {
+
+	/**
+	 * Test resulting in an error.
+	 *
+	 * @return void
+	 *
+	 * @throws Exception For test purposes.
+	 */
+	protected function testForListener() {
+		throw new Exception();
+	}
+}

--- a/tests/TestListeners/Fixtures/WarningPHPUnitGte7.php
+++ b/tests/TestListeners/Fixtures/WarningPHPUnitGte7.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Yoast\PHPUnitPolyfills\Tests\TestListeners\Fixtures;
+
+use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Warning as PHPUnit_Warning;
+
+/**
+ * Fixture to generate a test warning to pass to the test listener.
+ *
+ * @requires PHPUnit 7.0
+ */
+class WarningPHPUnitGte7 extends TestCase {
+
+	/**
+	 * Test resulting in a warning.
+	 *
+	 * @return void
+	 *
+	 * @throws PHPUnit_Warning For test purposes.
+	 */
+	protected function testForListener() {
+		throw new PHPUnit_Warning();
+	}
+}

--- a/tests/TestListeners/TestListenerTest.php
+++ b/tests/TestListeners/TestListenerTest.php
@@ -2,16 +2,11 @@
 
 namespace Yoast\PHPUnitPolyfills\Tests\TestListeners;
 
+use PHPUnit\Framework\TestCase as PHPUnitTestCase;
 use PHPUnit\Framework\TestResult;
+use Yoast\PHPUnitPolyfills\Autoload;
 use Yoast\PHPUnitPolyfills\TestCases\TestCase;
-use Yoast\PHPUnitPolyfills\Tests\TestListeners\Fixtures\Failure;
-use Yoast\PHPUnitPolyfills\Tests\TestListeners\Fixtures\Incomplete;
-use Yoast\PHPUnitPolyfills\Tests\TestListeners\Fixtures\Risky;
-use Yoast\PHPUnitPolyfills\Tests\TestListeners\Fixtures\Skipped;
-use Yoast\PHPUnitPolyfills\Tests\TestListeners\Fixtures\Success;
-use Yoast\PHPUnitPolyfills\Tests\TestListeners\Fixtures\TestError;
 use Yoast\PHPUnitPolyfills\Tests\TestListeners\Fixtures\TestListenerImplementation;
-use Yoast\PHPUnitPolyfills\Tests\TestListeners\Fixtures\Warning;
 
 /**
  * Basic test for the PHPUnit version-based TestListenerDefaultImplementation setup.
@@ -53,7 +48,7 @@ class TestListenerTest extends TestCase {
 	 * @return void
 	 */
 	public function testError() {
-		$test = new TestError( 'runTest' );
+		$test = $this->getTestObject( 'TestError' );
 		$test->run( $this->result );
 
 		$this->assertSame( 1, $this->listener->startTestCount, 'test start count failed' );
@@ -72,7 +67,7 @@ class TestListenerTest extends TestCase {
 	 * @return void
 	 */
 	public function testWarning() {
-		$test = new Warning( 'runTest' );
+		$test = $this->getTestObject( 'Warning' );
 		$test->run( $this->result );
 
 		$this->assertSame( 1, $this->listener->startTestCount, 'test start count failed' );
@@ -86,7 +81,7 @@ class TestListenerTest extends TestCase {
 	 * @return void
 	 */
 	public function testFailure() {
-		$test = new Failure( 'runTest' );
+		$test = $this->getTestObject( 'Failure' );
 		$test->run( $this->result );
 
 		$this->assertSame( 1, $this->listener->startTestCount, 'test start count failed' );
@@ -100,7 +95,7 @@ class TestListenerTest extends TestCase {
 	 * @return void
 	 */
 	public function testIncomplete() {
-		$test = new Incomplete( 'runTest' );
+		$test = $this->getTestObject( 'Incomplete' );
 		$test->run( $this->result );
 
 		$this->assertSame( 1, $this->listener->startTestCount, 'test start count failed' );
@@ -118,7 +113,7 @@ class TestListenerTest extends TestCase {
 	 * @return void
 	 */
 	public function testRisky() {
-		$test = new Risky( 'runTest' );
+		$test = $this->getTestObject( 'Risky' );
 		$test->run( $this->result );
 
 		$this->assertSame( 1, $this->listener->startTestCount, 'test start count failed' );
@@ -132,7 +127,7 @@ class TestListenerTest extends TestCase {
 	 * @return void
 	 */
 	public function testSkipped() {
-		$test = new Skipped( 'runTest' );
+		$test = $this->getTestObject( 'Skipped' );
 		$test->run( $this->result );
 
 		$this->assertSame( 1, $this->listener->startTestCount, 'test start count failed' );
@@ -146,10 +141,33 @@ class TestListenerTest extends TestCase {
 	 * @return void
 	 */
 	public function testStartStop() {
-		$test = new Success( 'runTest' );
+		$test = $this->getTestObject( 'Success' );
 		$test->run( $this->result );
 
 		$this->assertSame( 1, $this->listener->startTestCount, 'test start count failed' );
 		$this->assertSame( 1, $this->listener->endTestCount, 'test end count failed' );
+	}
+
+	/**
+	 * Helper method to get the right Test class object.
+	 *
+	 * Toggles between different versions of the same Test class object:
+	 * - Base version using `runTest()` method, compatible with PHPUnit < 10.0.
+	 * - Version using `testForListener()` method, compatible with PHPUnit > 7.0.
+	 *
+	 * @param string $className Base class name of the test class to instantiate.
+	 *
+	 * @return PHPUnitTestCase
+	 */
+	private function getTestObject( $className ) {
+		$className = '\Yoast\PHPUnitPolyfills\Tests\TestListeners\Fixtures\\' . $className;
+		$testName  = 'runTest';
+
+		if ( \version_compare( Autoload::getPHPUnitVersion(), '7.0.0', '>=' ) ) {
+			$className .= 'PHPUnitGte7';
+			$testName   = 'testForListener';
+		}
+
+		return new $className( $testName );
 	}
 }


### PR DESCRIPTION
Initial tweaks to make the tests compatible with PHPUnit 10.x, which enforces a `mixed` return type for the `TestCase::runTest()` method.

To test the TestListener, prior to PHPUnit 7.0, overloading the `runTest()` method works best, but as of PHPUnit 10.0, the `runTest()` method has a `mixed` return type declaration (PHP 8.0+).
However, since PHPUnit 7.0, testing the TestListener also works when the test name with which the `TestCase` is instantiated is not `runTest()`.

So either way, the fixtures used for the TestListener tests need to be duplicated and have two variations.

Now the choice was which option to choose:
* Duplicate the classes and add a return type to the `runTest()` method.
* Duplicate the classes and rename the test method.

I investigated both options and have decided to implement option 2 as `void` is not accepted as covariant with `mixed` and these methods are all `void` methods, so adding `mixed` as the return type would be misrepresenting the functionality.

The toggle for which test class to load for the various tests has been implemented with a helper method.