### PR TITLE
AssertClosedResource: improve error messages

### DIFF
--- a/src/Polyfills/AssertClosedResource.php
+++ b/src/Polyfills/AssertClosedResource.php
@@ -2,6 +2,8 @@
 
 namespace Yoast\PHPUnitPolyfills\Polyfills;
 
+use PHPUnit\SebastianBergmann\Exporter\Exporter as Exporter_In_Phar;
+use SebastianBergmann\Exporter\Exporter;
 use Yoast\PHPUnitPolyfills\Helpers\ResourceHelper;
 
 /**
@@ -24,7 +26,8 @@ trait AssertClosedResource {
 	 */
 	public static function assertIsClosedResource( $actual, $message = '' ) {
 		if ( $message === '' ) {
-			$message = \sprintf( 'Failed asserting that %s is of type "resource (closed)"', \var_export( $actual, true ) );
+			$exporter = \class_exists( 'SebastianBergmann\Exporter\Exporter' ) ? new Exporter() : new Exporter_In_Phar();
+			$message  = \sprintf( 'Failed asserting that %s is of type "resource (closed)"', $exporter->export( $actual ) );
 		}
 
 		static::assertTrue( ResourceHelper::isClosedResource( $actual ), $message );
@@ -40,7 +43,12 @@ trait AssertClosedResource {
 	 */
 	public static function assertIsNotClosedResource( $actual, $message = '' ) {
 		if ( $message === '' ) {
-			$message = \sprintf( 'Failed asserting that %s is not of type "resource (closed)"', \var_export( $actual, true ) );
+			$exporter = \class_exists( 'SebastianBergmann\Exporter\Exporter' ) ? new Exporter() : new Exporter_In_Phar();
+			$type     = $exporter->export( $actual );
+			if ( $type === 'NULL' ) {
+				$type = 'resource (closed)';
+			}
+			$message = \sprintf( 'Failed asserting that %s is not of type "resource (closed)"', $type );
 		}
 
 		static::assertFalse( ResourceHelper::isClosedResource( $actual ), $message );

--- a/tests/Polyfills/AssertClosedResourceTestCase.php
+++ b/tests/Polyfills/AssertClosedResourceTestCase.php
@@ -45,7 +45,11 @@ abstract class AssertClosedResourceTestCase extends TestCase {
 	 * @return void
 	 */
 	public function isNotClosedResourceExpectExceptionOnClosedResource( $actual ) {
-		$msg       = 'Failed asserting that NULL is not of type "resource (closed)"';
+		/*
+		 * PHPUnit itself will report closed resources as `NULL` prior to Exporter 3.0.4/4.1.4.
+		 * See: https://github.com/sebastianbergmann/exporter/pull/37
+		 */
+		$pattern   = '`^Failed asserting that (resource \(closed\)|NULL) is not of type "resource \(closed\)"`';
 		$exception = 'PHPUnit\Framework\AssertionFailedError';
 		if ( \class_exists( 'PHPUnit_Framework_AssertionFailedError' ) ) {
 			// PHPUnit < 6.
@@ -53,7 +57,7 @@ abstract class AssertClosedResourceTestCase extends TestCase {
 		}
 
 		$this->expectException( $exception );
-		$this->expectExceptionMessage( $msg );
+		$this->expectExceptionMessageMatches( $pattern );
 
 		self::assertIsNotClosedResource( $actual );
 	}


### PR DESCRIPTION
The `sebastian/exporter` package has been a dependency of PHPUnit from before PHPUnit 4.8.x (minimum supported version by this library), so it is safe to use the same variable export methodology as PHPUnit itself uses.

The class is prefixed via PHP_Scoper when it is includes as part of a PHPUnit Phar file and the toggle added will make sure the class can be loaded both when run via a Composer install, as well as when run via a Phar file.

Also note that the Exporter reports closed resources as `NULL`. This has been reported upstream via https://github.com/sebastianbergmann/exporter/issues/36 and for the polyfill a fix has been put in place to work around this.

Props to @schlessera for the feedback leading to this improvement.

**Important**:
While the `sebastian/exporter` package has, in effect, now become a direct dependency of the Polyfills, I'm not going to declare it as such in the `composer.json` file as for all supported PHPUnit versions, the package will already be available via PHPUnit itself, whether installed via Composer or as a PHAR.
This prevent potential version conflicts when tests are run via the PHAR, while the Polyfills have been installed via Composer and saves hassle of having to take care of autoloading the Exporter file, while it will be loaded for PHPUnit itself anyway.

If at some point in the future, PHPUnit would no longer require the Exporter package as a dependency, this should be re-evaluated.