### PR TITLE
PHP 8.2: allow dynamic property on test fixture

### DIFF
--- a/tests/Helpers/Fixtures/ClassWithProperties.php
+++ b/tests/Helpers/Fixtures/ClassWithProperties.php
@@ -2,9 +2,12 @@
 
 namespace Yoast\PHPUnitPolyfills\Tests\Helpers\Fixtures;
 
+use AllowDynamicProperties;
+
 /**
  * Fixture to test the AssertAttributeHelper.
  */
+#[AllowDynamicProperties]
 class ClassWithProperties {
 
 	/**


### PR DESCRIPTION
Dynamic (non-explicitly declared) property usage is expected to be deprecated as of PHP 8.2 and will become a fatal error in PHP 9.0.

There are a number of ways to mitigate this:
* If it's an accidental typo for a declared property: fix the typo.
* For known properties: declare them on the class.
* For unknown properties: add the magic `__get()`, `__set()` et al methods to the class or let the class extend `stdClass` which has highly optimized versions of these magic methods build in.
* For unknown _use of_ dynamic properties, the `#[AllowDynamicProperties]` attribute can be added to the class. The attribute will automatically be inherited by child classes.

In this case, the test is intentionally setting a dynamic property, so using the attribute is the best way to safeguard the handling of this functionality.

Refs:
* https://wiki.php.net/rfc/deprecate_dynamic_properties