### PR TITLE
GH Actions/test: PHPUnit 10 needs PHP 8.1

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -61,7 +61,7 @@ jobs:
             phpunit: 'auto'
             experimental: true
 
-          - php: '8.0'
+          - php: '8.1'
             phpunit: '^10.0'
             experimental: true
 


### PR DESCRIPTION
The minimum PHP requirement for PHPUnit 10 has been changed to PHP 8.1.

Ref: https://github.com/sebastianbergmann/phpunit/commit/95b61586c5d9b90bcaa516ddca0af00efc408940