### PR TITLE
GH Actions: various tweaks

### DIFF
--- a/.github/workflows/cs.yml
+++ b/.github/workflows/cs.yml
@@ -41,8 +41,9 @@ jobs:
 
       # Check the code-style consistency of the PHP files.
       - name: Check PHP code style
-        continue-on-error: true
+        id: phpcs
         run: composer check-cs -- --report-full --report-checkstyle=./phpcs-report.xml
 
       - name: Show PHPCS results in PR
+        if: ${{ always() && steps.phpcs.outcome == 'failure' }}
         run: cs2pr ./phpcs-report.xml

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -24,8 +24,6 @@ jobs:
 
     name: "Lint: PHP ${{ matrix.php }}"
 
-    continue-on-error: ${{ matrix.php == '8.2' }}
-
     steps:
       - name: Checkout code
         uses: actions/checkout@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ jobs:
 
     strategy:
       matrix:
-        php: ['5.4', '5.5', '5.6', '7.0', '7.1', '7.2', '7.3', '7.4', '8.0', '8.1']
+        php: ['5.4', '5.5', '5.6', '7.0', '7.1', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2']
         phpunit: ['auto']
         experimental: [false]
 
@@ -55,13 +55,16 @@ jobs:
           - php: '8.0'
             phpunit: '9.3.0'
             experimental: false
+          - php: '8.1'
+            phpunit: '9.3.0'
+            experimental: false
 
           # Experimental builds.
-          - php: '8.2'
-            phpunit: 'auto'
+          - php: '8.1'
+            phpunit: '^10.0'
             experimental: true
 
-          - php: '8.1'
+          - php: '8.2'
             phpunit: '^10.0'
             experimental: true
 
@@ -86,16 +89,8 @@ jobs:
 
       # Install dependencies and handle caching in one go.
       # @link https://github.com/marketplace/actions/install-composer-dependencies
-      - name: Install Composer dependencies for PHP < 8.2
-        if: ${{ matrix.php < 8.2 }}
+      - name: Install Composer dependencies
         uses: "ramsey/composer-install@v2"
-
-      # For PHP 8.2 and above, we need to install with ignore platform reqs as not all dependencies allow it yet.
-      - name: Install Composer dependencies for PHP >= 8.2
-        if: ${{ matrix.php >= 8.2 }}
-        uses: "ramsey/composer-install@v2"
-        with:
-          composer-options: --ignore-platform-reqs
 
       - name: Run the unit tests
         if: ${{ matrix.phpunit != '^10.0' }}


### PR DESCRIPTION
### GH Actions: harden the workflow against PHPCS ruleset errors

If there is a ruleset error, the `cs2pr` action doesn't receive an `xml` report and exits with a `0` error code, even though the PHPCS run failed (though not on CS errors, but on a ruleset error).

This changes the GH Actions workflow to allow for that situation and still fail the build in that case.

### GH Action: PHP 8.2 builds are no longer allowed to fail

Includes:
* Removing the `composer install` toggle for PHP 8.2.
* Adding a build against PHP 8.2 for PHPUnit 10.0.0.