### PR TITLE
Changelog for release 1.0.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,21 @@ This projects adheres to [Keep a CHANGELOG](http://keepachangelog.com/) and uses
 
 _Nothing yet._
 
+## [1.0.4] - 2022-11-16
+
+This is a maintenance release.
+
+### Changed
+* The `Yoast\PHPUnitPolyfills\Autoload` class is now `final`. PR [#77].
+* README: clear up minor language confusion. Props [Phil E. Taylor] and [fredericgboutin-yapla] for pointing it out.
+* README: fix links which were broken due to an upstream branch rename. PR [#80].
+* Verified PHP 8.2 compatibility.
+* General housekeeping.
+
+[#77]: https://github.com/Yoast/PHPUnit-Polyfills/pull/77
+[#80]: https://github.com/Yoast/PHPUnit-Polyfills/pull/80
+
+
 ## [1.0.3] - 2021-11-23
 
 ### Changed
@@ -111,6 +126,7 @@ Initial release.
 
 
 [Unreleased]: https://github.com/Yoast/PHPUnit-Polyfills/compare/main...HEAD
+[1.0.4]: https://github.com/Yoast/PHPUnit-Polyfills/compare/1.0.3...1.0.4
 [1.0.3]: https://github.com/Yoast/PHPUnit-Polyfills/compare/1.0.2...1.0.3
 [1.0.2]: https://github.com/Yoast/PHPUnit-Polyfills/compare/1.0.1...1.0.2
 [1.0.1]: https://github.com/Yoast/PHPUnit-Polyfills/compare/1.0.0...1.0.1
@@ -119,8 +135,10 @@ Initial release.
 [0.1.0]: https://github.com/Yoast/PHPUnit-Polyfills/compare/e8f8b7a73737aa9a5974bd9c73d2bd8d09f69873...0.1.0
 
 [Alain Schlesser]: https://github.com/schlessera
+[fredericgboutin-yapla]: https://github.com/fredericgboutin-yapla
 [Gary Jones]: https://github.com/GaryJones
 [Marc Siegrist]: https://github.com/mergeMarc
 [Mark Baker]: https://github.com/MarkBaker
 [Pascal Birchler]: https://github.com/swissspidy
+[Phil E. Taylor]: https://github.com/PhilETaylor
 [Pierre Gordon]: https://github.com/pierlon

--- a/README.md
+++ b/README.md
@@ -6,12 +6,13 @@ PHPUnit Polyfills
 [![Lint Build Status](https://github.com/Yoast/PHPUnit-Polyfills/actions/workflows/lint.yml/badge.svg)](https://github.com/Yoast/PHPUnit-Polyfills/actions/workflows/lint.yml)
 [![Test Build Status](https://github.com/Yoast/PHPUnit-Polyfills/actions/workflows/test.yml/badge.svg)](https://github.com/Yoast/PHPUnit-Polyfills/actions/workflows/test.yml)
 [![Minimum PHP Version](https://img.shields.io/packagist/php-v/yoast/phpunit-polyfills.svg?maxAge=3600)](https://packagist.org/packages/yoast/phpunit-polyfills)
-[![License: BSD3](https://poser.pugx.org/yoast/phpunit-polyfills/license)](https://github.com/Yoast/PHPUnit-Polyfills/blob/master/LICENSE)
+[![License: BSD3](https://poser.pugx.org/yoast/phpunit-polyfills/license)](https://github.com/Yoast/PHPUnit-Polyfills/blob/main/LICENSE)
 
 
 Set of polyfills for changed PHPUnit functionality to allow for creating PHPUnit cross-version compatible tests.
 
 * [Requirements](#requirements)
+    - [Autoloading](#autoloading)
 * [Installation](#installation)
 * [Why use the PHPUnit Polyfills?](#why-use-the-phpunit-polyfills)
 * [Using this library](#using-this-library)
@@ -47,7 +48,11 @@ To update this package, run:
 composer update --dev yoast/phpunit-polyfills --with-dependencies
 ```
 
-Make sure to either use the Composer `vendor/autoload.php` file _as_ your test bootstrap file; òr require the `vendor/yoast/phpunit-polyfills/phpunitpolyfills-autoload.php` file _in_ your test bootstrap.
+### Autoloading
+
+Make sure to:
+* Either use the Composer `vendor/autoload.php` file _as_ your test bootstrap file;
+* Or require the `vendor/yoast/phpunit-polyfills/phpunitpolyfills-autoload.php` file _in_ your test bootstrap.
 
 
 Why use the PHPUnit Polyfills?
@@ -321,7 +326,7 @@ Polyfills the following methods:
 | `TestCase::`[`expectNotice()`]      | [`expectNoticeMessage()`]      | [`expectNoticeMessageMatches()`]      |
 | `TestCase::`[`expectDeprecation()`] | [`expectDeprecationMessage()`] | [`expectDeprecationMessageMatches()`] |
 
-These method were introduced in PHPUnit 8.4.0 as alternatives to using `TestCase::expectException()` et al for expecting PHP native errors, warnings and notices.
+These methods were introduced in PHPUnit 8.4.0 as alternatives to using `TestCase::expectException()` et al for expecting PHP native errors, warnings and notices.
 Using `TestCase::expectException*()` for testing PHP native notices was soft deprecated in PHPUnit 8.4.0, hard deprecated (warning) in PHPUnit 9.0.0 and (will be) removed in PHPUnit 10.0.0.
 
 [`expectError()`]:                     https://phpunit.readthedocs.io/en/main/writing-tests-for-phpunit.html#testing-php-errors-warnings-and-notices

--- a/phpunitpolyfills-autoload.php
+++ b/phpunitpolyfills-autoload.php
@@ -17,7 +17,7 @@ if ( \class_exists( 'Yoast\PHPUnitPolyfills\Autoload', false ) === false ) {
 		 *
 		 * @var string
 		 */
-		const VERSION = '1.0.3';
+		const VERSION = '1.0.4';
 
 		/**
 		 * Loads a class.


### PR DESCRIPTION
Includes updating the `VERSION` constant in the `Autoload` class.

Includes minor tweaks to the README to clear up some confusion.