### PR TITLE
GH Actions: various tweaks

### DIFF
--- a/.github/workflows/cs.yml
+++ b/.github/workflows/cs.yml
@@ -45,7 +45,7 @@ jobs:
       # Check the code-style consistency of the PHP files.
       - name: Check PHP code style
         id: phpcs
-        run: composer check-cs -- --report-full --report-checkstyle=./phpcs-report.xml
+        run: composer check-cs -- --no-cache --report-full --report-checkstyle=./phpcs-report.xml
 
       - name: Show PHPCS results in PR
         if: ${{ always() && steps.phpcs.outcome == 'failure' }}

--- a/.github/workflows/cs.yml
+++ b/.github/workflows/cs.yml
@@ -34,8 +34,8 @@ jobs:
       - name: Install Composer dependencies
         uses: "ramsey/composer-install@v2"
         with:
-          # Bust the cache at least once a month - output format: YYYY-MM-DD.
-          custom-cache-suffix: $(date -u -d "-0 month -$(($(date +%d)-1)) days" "+%F")
+          # Bust the cache at least once a month - output format: YYYY-MM.
+          custom-cache-suffix: $(date -u "+%Y-%m")
 
       # Validate the composer.json file.
       # @link https://getcomposer.org/doc/03-cli.md#validate

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -20,7 +20,9 @@ jobs:
 
     strategy:
       matrix:
-        php: ['5.4', '5.5', '5.6', '7.0', '7.1', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2']
+        php: ['5.4', '5.5', '5.6', '7.0', '7.1', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3']
+
+    continue-on-error: ${{ matrix.php == '8.3' }}
 
     name: "Lint: PHP ${{ matrix.php }}"
 
@@ -40,9 +42,18 @@ jobs:
 
       # Install dependencies and handle caching in one go.
       # @link https://github.com/marketplace/actions/install-composer-dependencies
-      - name: Install Composer dependencies
+      - name: Install Composer dependencies - normal
+        if: matrix.php != '8.3'
         uses: "ramsey/composer-install@v2"
         with:
+          # Bust the cache at least once a month - output format: YYYY-MM.
+          custom-cache-suffix: $(date -u "+%Y-%m")
+
+      - name: Install Composer dependencies - ignore PHP restrictions
+        if: matrix.php == '8.3'
+        uses: "ramsey/composer-install@v2"
+        with:
+          composer-options: --ignore-platform-req=php+
           # Bust the cache at least once a month - output format: YYYY-MM.
           custom-cache-suffix: $(date -u "+%Y-%m")
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -43,8 +43,8 @@ jobs:
       - name: Install Composer dependencies
         uses: "ramsey/composer-install@v2"
         with:
-          # Bust the cache at least once a month - output format: YYYY-MM-DD.
-          custom-cache-suffix: $(date -u -d "-0 month -$(($(date +%d)-1)) days" "+%F")
+          # Bust the cache at least once a month - output format: YYYY-MM.
+          custom-cache-suffix: $(date -u "+%Y-%m")
 
       - name: "Lint PHP files against parse errors - PHP < 7.0"
         if: ${{ matrix.php < 7.0 }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -92,8 +92,8 @@ jobs:
       - name: Install Composer dependencies
         uses: "ramsey/composer-install@v2"
         with:
-          # Bust the cache at least once a month - output format: YYYY-MM-DD.
-          custom-cache-suffix: $(date -u -d "-0 month -$(($(date +%d)-1)) days" "+%F")
+          # Bust the cache at least once a month - output format: YYYY-MM.
+          custom-cache-suffix: $(date -u "+%Y-%m")
 
       - name: Run the unit tests
         if: ${{ matrix.phpunit != '^10.0' }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -58,12 +58,18 @@ jobs:
           - php: '8.1'
             phpunit: '9.3.0'
             experimental: false
+          - php: '8.2'
+            phpunit: '9.3.0'
+            experimental: false
 
           # Experimental builds.
+          - php: '8.3'
+            phpunit: 'auto'
+            experimental: true
+
           - php: '8.1'
             phpunit: '^10.0'
             experimental: true
-
           - php: '8.2'
             phpunit: '^10.0'
             experimental: true
@@ -89,9 +95,18 @@ jobs:
 
       # Install dependencies and handle caching in one go.
       # @link https://github.com/marketplace/actions/install-composer-dependencies
-      - name: Install Composer dependencies
+      - name: Install Composer dependencies - normal
+        if: matrix.php != '8.3'
         uses: "ramsey/composer-install@v2"
         with:
+          # Bust the cache at least once a month - output format: YYYY-MM.
+          custom-cache-suffix: $(date -u "+%Y-%m")
+
+      - name: Install Composer dependencies - ignore PHP restrictions
+        if: matrix.php == '8.3'
+        uses: "ramsey/composer-install@v2"
+        with:
+          composer-options: --ignore-platform-req=php+
           # Bust the cache at least once a month - output format: YYYY-MM.
           custom-cache-suffix: $(date -u "+%Y-%m")
 


### PR DESCRIPTION
### GH Actions: minor simplification

... of the bash `date` command in the earlier pulled cache busting.

### GH Actions: improve performance of the CS step

All the repos in the Yoast organisation contain a `<arg name="cache" value="./.cache/phpcs.cache"/>` directive in the PHPCS ruleset.
This directive makes running PHPCS faster by caching the run results in a file and only scanning changed files when running PHPCS again.

However, when there is no cache available, running with the `cache` option enabled will make PHPCS _slower_ as the cache needs to be created and the file read/write actions slow PHPCS down.

In GH Actions, we are not caching the PHPCS `cache` file, which means that there is cache file available and running with `cache` will be slower.

By adding the `--no-cache` option, the `cache` directive in the ruleset is ignored, which should result in a slightly faster runtime for the CS workflow.

Note: the alternative would be to _cache_ the cache file in GH Actions, but aside from the two very frequently changing repos, there's not much point doing that.

### GH Actions: enable linting and testing against PHP 8.3

While early days for PHP 8.3, as this is a test related package, it needs to be ready early, so better to start running the lint and test workflows against PHP 8.3 already.

Include adding a "low" dependency test run for PHP 8.2.