### PR TITLE
Tests: make dataproviders `static`

### DIFF
--- a/tests/Polyfills/AssertClosedResourceNotResourceTest.php
+++ b/tests/Polyfills/AssertClosedResourceNotResourceTest.php
@@ -76,7 +76,7 @@ final class AssertClosedResourceNotResourceTest extends TestCase {
 	 *
 	 * @return array
 	 */
-	public function dataNotResource() {
+	public static function dataNotResource() {
 		return [
 			'null'            => [ null ],
 			'false'           => [ false ],

--- a/tests/Polyfills/AssertStringContainsTest.php
+++ b/tests/Polyfills/AssertStringContainsTest.php
@@ -148,7 +148,7 @@ final class AssertStringContainsTest extends TestCase {
 	 *
 	 * @return array
 	 */
-	public function dataHaystacks() {
+	public static function dataHaystacks() {
 		return [
 			'foobar as haystack' => [ 'foobar' ],
 			'empty haystack'     => [ '' ],

--- a/tests/TestCases/TestCaseTestTrait.php
+++ b/tests/TestCases/TestCaseTestTrait.php
@@ -16,7 +16,7 @@ trait TestCaseTestTrait {
 	 *
 	 * @return array[]
 	 */
-	public function dataHaveFixtureMethodsBeenTriggered() {
+	public static function dataHaveFixtureMethodsBeenTriggered() {
 		return [
 			[ 1, 1, 0, 1, 0 ],
 			[ 1, 2, 1, 2, 1 ],


### PR DESCRIPTION
As of PHPUnit 10, data providers are (again) expected to be `static` methods.

This updates the test suite for the polyfills to respect that.