### PR TITLE
Polyfills: improve handling of custom error message

### DIFF
--- a/src/Polyfills/AssertClosedResource.php
+++ b/src/Polyfills/AssertClosedResource.php
@@ -25,12 +25,14 @@ trait AssertClosedResource {
 	 * @return void
 	 */
 	public static function assertIsClosedResource( $actual, $message = '' ) {
-		if ( $message === '' ) {
-			$exporter = \class_exists( 'SebastianBergmann\Exporter\Exporter' ) ? new Exporter() : new Exporter_In_Phar();
-			$message  = \sprintf( 'Failed asserting that %s is of type "resource (closed)"', $exporter->export( $actual ) );
+		$exporter = \class_exists( 'SebastianBergmann\Exporter\Exporter' ) ? new Exporter() : new Exporter_In_Phar();
+		$msg      = \sprintf( 'Failed asserting that %s is of type "resource (closed)"', $exporter->export( $actual ) );
+
+		if ( $message !== '' ) {
+			$msg = $message . \PHP_EOL . $msg;
 		}
 
-		static::assertTrue( ResourceHelper::isClosedResource( $actual ), $message );
+		static::assertTrue( ResourceHelper::isClosedResource( $actual ), $msg );
 	}
 
 	/**
@@ -42,16 +44,18 @@ trait AssertClosedResource {
 	 * @return void
 	 */
 	public static function assertIsNotClosedResource( $actual, $message = '' ) {
-		if ( $message === '' ) {
-			$exporter = \class_exists( 'SebastianBergmann\Exporter\Exporter' ) ? new Exporter() : new Exporter_In_Phar();
-			$type     = $exporter->export( $actual );
-			if ( $type === 'NULL' ) {
-				$type = 'resource (closed)';
-			}
-			$message = \sprintf( 'Failed asserting that %s is not of type "resource (closed)"', $type );
+		$exporter = \class_exists( 'SebastianBergmann\Exporter\Exporter' ) ? new Exporter() : new Exporter_In_Phar();
+		$type     = $exporter->export( $actual );
+		if ( $type === 'NULL' ) {
+			$type = 'resource (closed)';
+		}
+		$msg = \sprintf( 'Failed asserting that %s is not of type "resource (closed)"', $type );
+
+		if ( $message !== '' ) {
+			$msg = $message . \PHP_EOL . $msg;
 		}
 
-		static::assertFalse( ResourceHelper::isClosedResource( $actual ), $message );
+		static::assertFalse( ResourceHelper::isClosedResource( $actual ), $msg );
 	}
 
 	/**

--- a/src/Polyfills/AssertFileDirectory.php
+++ b/src/Polyfills/AssertFileDirectory.php
@@ -32,11 +32,12 @@ trait AssertFileDirectory {
 			throw PHPUnit_Util_InvalidArgumentHelper::factory( 1, 'string' );
 		}
 
-		if ( $message === '' ) {
-			$message = \sprintf( 'Failed asserting that "%s" is readable', $filename );
+		$msg = \sprintf( 'Failed asserting that "%s" is readable', $filename );
+		if ( $message !== '' ) {
+			$msg = $message . \PHP_EOL . $msg;
 		}
 
-		static::assertTrue( \is_readable( $filename ), $message );
+		static::assertTrue( \is_readable( $filename ), $msg );
 	}
 
 	/**
@@ -54,11 +55,12 @@ trait AssertFileDirectory {
 			throw PHPUnit_Util_InvalidArgumentHelper::factory( 1, 'string' );
 		}
 
-		if ( $message === '' ) {
-			$message = \sprintf( 'Failed asserting that "%s" is not readable', $filename );
+		$msg = \sprintf( 'Failed asserting that "%s" is not readable', $filename );
+		if ( $message !== '' ) {
+			$msg = $message . \PHP_EOL . $msg;
 		}
 
-		static::assertFalse( \is_readable( $filename ), $message );
+		static::assertFalse( \is_readable( $filename ), $msg );
 	}
 
 	/**
@@ -76,11 +78,12 @@ trait AssertFileDirectory {
 			throw PHPUnit_Util_InvalidArgumentHelper::factory( 1, 'string' );
 		}
 
-		if ( $message === '' ) {
-			$message = \sprintf( 'Failed asserting that "%s" is writable', $filename );
+		$msg = \sprintf( 'Failed asserting that "%s" is writable', $filename );
+		if ( $message !== '' ) {
+			$msg = $message . \PHP_EOL . $msg;
 		}
 
-		static::assertTrue( \is_writable( $filename ), $message );
+		static::assertTrue( \is_writable( $filename ), $msg );
 	}
 
 	/**
@@ -98,11 +101,12 @@ trait AssertFileDirectory {
 			throw PHPUnit_Util_InvalidArgumentHelper::factory( 1, 'string' );
 		}
 
-		if ( $message === '' ) {
-			$message = \sprintf( 'Failed asserting that "%s" is not writable', $filename );
+		$msg = \sprintf( 'Failed asserting that "%s" is not writable', $filename );
+		if ( $message !== '' ) {
+			$msg = $message . \PHP_EOL . $msg;
 		}
 
-		static::assertFalse( \is_writable( $filename ), $message );
+		static::assertFalse( \is_writable( $filename ), $msg );
 	}
 
 	/**
@@ -120,11 +124,12 @@ trait AssertFileDirectory {
 			throw PHPUnit_Util_InvalidArgumentHelper::factory( 1, 'string' );
 		}
 
-		if ( $message === '' ) {
-			$message = \sprintf( 'Failed asserting that directory "%s" exists', $directory );
+		$msg = \sprintf( 'Failed asserting that directory "%s" exists', $directory );
+		if ( $message !== '' ) {
+			$msg = $message . \PHP_EOL . $msg;
 		}
 
-		static::assertTrue( \is_dir( $directory ), $message );
+		static::assertTrue( \is_dir( $directory ), $msg );
 	}
 
 	/**
@@ -142,11 +147,12 @@ trait AssertFileDirectory {
 			throw PHPUnit_Util_InvalidArgumentHelper::factory( 1, 'string' );
 		}
 
-		if ( $message === '' ) {
-			$message = \sprintf( 'Failed asserting that directory "%s" does not exist', $directory );
+		$msg = \sprintf( 'Failed asserting that directory "%s" does not exist', $directory );
+		if ( $message !== '' ) {
+			$msg = $message . \PHP_EOL . $msg;
 		}
 
-		static::assertFalse( \is_dir( $directory ), $message );
+		static::assertFalse( \is_dir( $directory ), $msg );
 	}
 
 	/**

--- a/src/Polyfills/AssertStringContains.php
+++ b/src/Polyfills/AssertStringContains.php
@@ -69,11 +69,12 @@ trait AssertStringContains {
 	 */
 	public static function assertStringNotContainsString( $needle, $haystack, $message = '' ) {
 		if ( $needle === '' ) {
-			if ( $message === '' ) {
-				$message = "Failed asserting that '{$haystack}' does not contain \"{$needle}\".";
+			$msg = "Failed asserting that '{$haystack}' does not contain \"\".";
+			if ( $message !== '' ) {
+				$msg = $message . \PHP_EOL . $msg;
 			}
 
-			static::fail( $message );
+			static::fail( $msg );
 		}
 
 		static::assertNotContains( $needle, $haystack, $message );
@@ -90,11 +91,12 @@ trait AssertStringContains {
 	 */
 	public static function assertStringNotContainsStringIgnoringCase( $needle, $haystack, $message = '' ) {
 		if ( $needle === '' ) {
-			if ( $message === '' ) {
-				$message = "Failed asserting that '{$haystack}' does not contain \"{$needle}\".";
+			$msg = "Failed asserting that '{$haystack}' does not contain \"\".";
+			if ( $message !== '' ) {
+				$msg = $message . \PHP_EOL . $msg;
 			}
 
-			static::fail( $message );
+			static::fail( $msg );
 		}
 
 		static::assertNotContains( $needle, $haystack, $message, true );

--- a/tests/Polyfills/AssertClosedResourceNotResourceTest.php
+++ b/tests/Polyfills/AssertClosedResourceNotResourceTest.php
@@ -40,6 +40,21 @@ final class AssertClosedResourceNotResourceTest extends TestCase {
 	}
 
 	/**
+	 * Verify that the assertIsClosedResource() method fails a test with the correct custom failure message,
+	 * when the custom $message parameter has been passed.
+	 *
+	 * @return void
+	 */
+	public function testAssertIsClosedResourceFailsWithCustomMessage() {
+		$pattern = '`^This assertion failed for reason XYZ\s+Failed asserting that .+? is of type ["]?resource \(closed\)["]?`s';
+
+		$this->expectException( $this->getAssertionFailedExceptionName() );
+		$this->expectExceptionMessageMatches( $pattern );
+
+		$this->assertIsClosedResource( 'text string', 'This assertion failed for reason XYZ' );
+	}
+
+	/**
 	 * Verify that the assertIsNotClosedResource() method passes the test when the variable
 	 * passed is not a resource.
 	 *
@@ -51,6 +66,24 @@ final class AssertClosedResourceNotResourceTest extends TestCase {
 	 */
 	public function testAssertIsNotClosedResource( $value ) {
 		self::assertIsNotClosedResource( $value );
+	}
+
+	/**
+	 * Verify that the assertIsNotClosedResource() method fails a test with the correct custom failure message,
+	 * when the custom $message parameter has been passed.
+	 *
+	 * @return void
+	 */
+	public function testAssertIsNotClosedResourceFailsWithCustomMessage() {
+		$pattern = '`^This assertion failed for reason XYZ\s+Failed asserting that .+? not of type ["]?resource \(closed\)["]?`s';
+
+		$this->expectException( $this->getAssertionFailedExceptionName() );
+		$this->expectExceptionMessageMatches( $pattern );
+
+		$resource = \opendir( __DIR__ . '/Fixtures/' );
+		\closedir( $resource );
+
+		$this->assertIsNotClosedResource( $resource, 'This assertion failed for reason XYZ' );
 	}
 
 	/**

--- a/tests/Polyfills/AssertFileDirectoryTest.php
+++ b/tests/Polyfills/AssertFileDirectoryTest.php
@@ -9,6 +9,8 @@ use TypeError;
 use Yoast\PHPUnitPolyfills\Polyfills\AssertFileDirectory;
 use Yoast\PHPUnitPolyfills\Polyfills\AssertionRenames;
 use Yoast\PHPUnitPolyfills\Polyfills\AssertIsType;
+use Yoast\PHPUnitPolyfills\Polyfills\ExpectException;
+use Yoast\PHPUnitPolyfills\Polyfills\ExpectExceptionMessageMatches;
 
 /**
  * Availability test for the functions polyfilled by the AssertFileDirectory trait.
@@ -20,6 +22,8 @@ final class AssertFileDirectoryTest extends TestCase {
 	use AssertFileDirectory;
 	use AssertionRenames;
 	use AssertIsType;
+	use ExpectException; // Needed for PHPUnit < 5.2.0 support.
+	use ExpectExceptionMessageMatches;
 
 	/**
 	 * Verify availability of the assertIsReadable() method.
@@ -59,6 +63,22 @@ final class AssertFileDirectoryTest extends TestCase {
 		}
 
 		$this->fail( 'Failed to assert that the expected "invalid argument" exception was thrown' );
+	}
+
+	/**
+	 * Verify that the assertIsReadable() method fails a test with the correct custom failure message,
+	 * when the custom $message parameter has been passed.
+	 *
+	 * @return void
+	 */
+	public function testAssertIsReadableFailsWithCustomMessage() {
+		$pattern = '`^This assertion failed for reason XYZ\s+Failed asserting that ".+?" is readable`';
+
+		$this->expectException( $this->getAssertionFailedExceptionName() );
+		$this->expectExceptionMessageMatches( $pattern );
+
+		$path = __DIR__ . \DIRECTORY_SEPARATOR . 'NotExisting.php';
+		$this->assertIsReadable( $path, 'This assertion failed for reason XYZ' );
 	}
 
 	/**
@@ -106,6 +126,24 @@ final class AssertFileDirectoryTest extends TestCase {
 	}
 
 	/**
+	 * Verify that the assertNotIsReadable() method fails a test with the correct custom failure message,
+	 * when the custom $message parameter has been passed.
+	 *
+	 * @requires PHPUnit < 9.1.0
+	 *
+	 * @return void
+	 */
+	public function testAssertNotIsReadableFailsWithCustomMessage() {
+		$pattern = '`^This assertion failed for reason XYZ\s+Failed asserting that ".+?" is not readable`';
+
+		$this->expectException( $this->getAssertionFailedExceptionName() );
+		$this->expectExceptionMessageMatches( $pattern );
+
+		$path = __DIR__ . \DIRECTORY_SEPARATOR . 'Fixtures/AssertFileDirectory_Readable.txt';
+		$this->assertNotIsReadable( $path, 'This assertion failed for reason XYZ' );
+	}
+
+	/**
 	 * Verify availability of the assertIsWritable() method.
 	 *
 	 * @return void
@@ -143,6 +181,22 @@ final class AssertFileDirectoryTest extends TestCase {
 		}
 
 		$this->fail( 'Failed to assert that the expected "invalid argument" exception was thrown' );
+	}
+
+	/**
+	 * Verify that the assertIsWritable() method fails a test with the correct custom failure message,
+	 * when the custom $message parameter has been passed.
+	 *
+	 * @return void
+	 */
+	public function testAssertIsWritableFailsWithCustomMessage() {
+		$pattern = '`^This assertion failed for reason XYZ\s+Failed asserting that ".+?" is writable`';
+
+		$this->expectException( $this->getAssertionFailedExceptionName() );
+		$this->expectExceptionMessageMatches( $pattern );
+
+		$path = __DIR__ . \DIRECTORY_SEPARATOR . 'NotExisting' . \DIRECTORY_SEPARATOR;
+		$this->assertIsWritable( $path, 'This assertion failed for reason XYZ' );
 	}
 
 	/**
@@ -190,6 +244,24 @@ final class AssertFileDirectoryTest extends TestCase {
 	}
 
 	/**
+	 * Verify that the assertNotIsWritable() method fails a test with the correct custom failure message,
+	 * when the custom $message parameter has been passed.
+	 *
+	 * @requires PHPUnit < 9.1.0
+	 *
+	 * @return void
+	 */
+	public function testAssertNotIsWritableFailsWithCustomMessage() {
+		$pattern = '`^This assertion failed for reason XYZ\s+Failed asserting that ".+?" is not writable`';
+
+		$this->expectException( $this->getAssertionFailedExceptionName() );
+		$this->expectExceptionMessageMatches( $pattern );
+
+		$path = __DIR__ . \DIRECTORY_SEPARATOR . 'Fixtures/AssertFileDirectory_Readable.txt';
+		$this->assertNotIsWritable( $path, 'This assertion failed for reason XYZ' );
+	}
+
+	/**
 	 * Verify availability of the assertDirectoryExists() method.
 	 *
 	 * @return void
@@ -227,6 +299,22 @@ final class AssertFileDirectoryTest extends TestCase {
 		}
 
 		$this->fail( 'Failed to assert that the expected "invalid argument" exception was thrown' );
+	}
+
+	/**
+	 * Verify that the assertDirectoryExists() method fails a test with the correct custom failure message,
+	 * when the custom $message parameter has been passed.
+	 *
+	 * @return void
+	 */
+	public function testAssertDirectoryExistsFailsWithCustomMessage() {
+		$pattern = '`^This assertion failed for reason XYZ\s+Failed asserting that directory ".+?" exists`';
+
+		$this->expectException( $this->getAssertionFailedExceptionName() );
+		$this->expectExceptionMessageMatches( $pattern );
+
+		$path = __DIR__ . \DIRECTORY_SEPARATOR . 'NotExisting' . \DIRECTORY_SEPARATOR;
+		$this->assertDirectoryExists( $path, 'This assertion failed for reason XYZ' );
 	}
 
 	/**
@@ -271,6 +359,24 @@ final class AssertFileDirectoryTest extends TestCase {
 		}
 
 		$this->fail( 'Failed to assert that the expected "invalid argument" exception was thrown' );
+	}
+
+	/**
+	 * Verify that the assertDirectoryNotExists() method fails a test with the correct custom failure message,
+	 * when the custom $message parameter has been passed.
+	 *
+	 * @requires PHPUnit < 9.1.0
+	 *
+	 * @return void
+	 */
+	public function testAssertDirectoryNotExistsFailsWithCustomMessage() {
+		$pattern = '`^This assertion failed for reason XYZ\s+Failed asserting that directory ".+?" does not exist`';
+
+		$this->expectException( $this->getAssertionFailedExceptionName() );
+		$this->expectExceptionMessageMatches( $pattern );
+
+		$path = __DIR__ . \DIRECTORY_SEPARATOR . 'Fixtures' . \DIRECTORY_SEPARATOR;
+		$this->assertDirectoryNotExists( $path, 'This assertion failed for reason XYZ' );
 	}
 
 	/**
@@ -404,5 +510,20 @@ final class AssertFileDirectoryTest extends TestCase {
 
 		\chmod( $tempFile, \octdec( '755' ) );
 		\unlink( $tempFile );
+	}
+
+	/**
+	 * Helper function: retrieve the name of the "assertion failed" exception to expect (PHPUnit cross-version).
+	 *
+	 * @return string
+	 */
+	public function getAssertionFailedExceptionName() {
+		$exception = 'PHPUnit\Framework\AssertionFailedError';
+		if ( \class_exists( 'PHPUnit_Framework_AssertionFailedError' ) ) {
+			// PHPUnit < 6.
+			$exception = 'PHPUnit_Framework_AssertionFailedError';
+		}
+
+		return $exception;
 	}
 }

--- a/tests/Polyfills/AssertStringContainsTest.php
+++ b/tests/Polyfills/AssertStringContainsTest.php
@@ -5,6 +5,7 @@ namespace Yoast\PHPUnitPolyfills\Tests\Polyfills;
 use PHPUnit\Framework\TestCase;
 use Yoast\PHPUnitPolyfills\Polyfills\AssertStringContains;
 use Yoast\PHPUnitPolyfills\Polyfills\ExpectException;
+use Yoast\PHPUnitPolyfills\Polyfills\ExpectExceptionMessageMatches;
 
 /**
  * Availability test for the functions polyfilled by the AssertStringContains trait.
@@ -15,6 +16,7 @@ final class AssertStringContainsTest extends TestCase {
 
 	use AssertStringContains;
 	use ExpectException; // Needed for PHPUnit < 5.2.0 support.
+	use ExpectExceptionMessageMatches;
 
 	/**
 	 * Verify availability of the assertStringContainsString() method.
@@ -143,6 +145,36 @@ final class AssertStringContainsTest extends TestCase {
 			'foobar as haystack' => [ 'foobar' ],
 			'empty haystack'     => [ '' ],
 		];
+	}
+
+	/**
+	 * Verify that the assertStringNotContainsString() method fails a test with a custom failure message,
+	 * when the custom $message parameter has been passed.
+	 *
+	 * @return void
+	 */
+	public function testAssertStringNotContainsStringFailsWithCustomMessage() {
+		$pattern = '`^This assertion failed for reason XYZ\s+Failed asserting that \'.+?\' does not contain ""\.`s';
+
+		$this->expectException( $this->getAssertionFailedExceptionName() );
+		$this->expectExceptionMessageMatches( $pattern );
+
+		$this->assertStringNotContainsString( '', 'something', 'This assertion failed for reason XYZ' );
+	}
+
+	/**
+	 * Verify that the assertStringNotContainsStringIgnoringCase() method fails a test with a custom failure message,
+	 * when the custom $message parameter has been passed.
+	 *
+	 * @return void
+	 */
+	public function testssertStringNotContainsStringIgnoringCaseFailsWithCustomMessage() {
+		$pattern = '`^This assertion failed for reason XYZ\s+Failed asserting that \'.+?\' does not contain ""\.`s';
+
+		$this->expectException( $this->getAssertionFailedExceptionName() );
+		$this->expectExceptionMessageMatches( $pattern );
+
+		$this->assertStringNotContainsStringIgnoringCase( '', 'something', 'This assertion failed for reason XYZ' );
 	}
 
 	/**


### PR DESCRIPTION
### AssertClosedResource: improve handling of custom error message

The assertions in the `AssertClosedResource` trait generate a specific error message.
However, if a custom `$message` parameter was passed, that message would not be displayed and only the custom `$message` would be shown when the assertion failed.

As the PHPUnit native error message from the _underlying_ assertion used - _"true is not false"_ - would be obscuring the real issue, this commit adjusts the code to always display the assertion specific error message as well.

Includes tests safeguarding the fix.

### AssertFileDirectory: improve handling of custom error message

Some of the assertions in the `AssertFileDirectory` trait generate a specific error message.
However, if a custom `$message` parameter was passed, that message would not be displayed and only the custom `$message` would be shown when the assertion failed.

As the PHPUnit native error message from the _underlying_ assertion used - _"true is not false"_ - would be obscuring the real issue, this commit adjusts the code to always display the assertion specific error message as well.

Includes tests safeguarding the fix.

### AssertStringContains: improve handling of custom error message

Some of the assertions in the `AssertStringContains` trait generate a specific error message.
However, if a custom `$message` parameter was passed, that message would not be displayed and only the custom `$message` would be shown when the assertion failed.

As the PHPUnit native error message from the _underlying_ assertion used - _"true is not false"_ - would be obscuring the real issue, this commit adjusts the code to always display the assertion specific error message as well.

Includes tests safeguarding the fix.