### PR TITLE
Docs: updates for branch rename and adding of 2.x branch

### DIFF
--- a/.github/RELEASE-CHECKLIST.md
+++ b/.github/RELEASE-CHECKLIST.md
@@ -1,7 +1,11 @@
-Template to use for release PRs from `develop` to `main`
+Template to use for release PRs from `#.x` to `main`
 ===========================================================
 
 Title: Release version x.x.x
+
+<!--
+If both a 1.x and a 2.x release are to be tagged, always tag the 1.x release first!
+-->
 
 ## Functional
 - [ ] Confirm that the most recent PHPUnit changelogs have been checked and that the library is still feature complete for those versions supported within the PHPUnit version constraints.
@@ -13,8 +17,8 @@ Title: Release version x.x.x
     Verify that a release link at the bottom of the `CHANGELOG.md` file has been added.
 - [ ] Merge this PR.
 - [ ] Make sure all CI builds are green.
-- [ ] Tag the release (careful, GH defaults to `develop`!).
-- [ ] Create a release from the tag (careful, GH defaults to `develop`!) & copy & paste the changelog to it.
+- [ ] Tag the release (careful, GH defaults to `2.x`!).
+- [ ] Create a release from the tag (careful, GH defaults to `2.x`!) & copy & paste the changelog to it.
     Make sure to copy the links to the issues and the links to the GH usernames from the bottom of the changelog!
 - [ ] Close the milestone.
 - [ ] Open a new milestone for the next release.

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Set of polyfills for changed PHPUnit functionality to allow for creating PHPUnit
 * [Installation](#installation)
     - [Autoloading](#autoloading)
 * [Why use the PHPUnit Polyfills?](#why-use-the-phpunit-polyfills)
+    - [PHPUnit support](#phpunit-support)
 * [Using this library](#using-this-library)
     - [Supported ways of calling the assertions](#supported-ways-of-calling-the-assertions)
     - [Use with PHPUnit < 5.7.0](#use-with-phpunit--570)
@@ -42,7 +43,7 @@ Installation
 
 To install this package, run:
 ```bash
-composer require --dev yoast/phpunit-polyfills
+composer require --dev yoast/phpunit-polyfills:"^1.0"
 ```
 
 To update this package, run:
@@ -68,6 +69,19 @@ The polyfills have been setup to allow tests to be _forward_-compatible. What th
 
 This puts the burden of upgrading to use the syntax of newer PHPUnit versions at the point when you want to _start_ running your tests on a newer version.
 By doing so, dropping support for an older PHPUnit version becomes as straight-forward as removing it from the version constraint in your `composer.json` file.
+
+### PHPUnit support
+
+* Releases in the `1.x` series of the PHPUnit Polyfills support PHPUnit 4.8 - 9.x.
+* Releases in the `2.x` series of the PHPUnit Polyfills support PHPUnit 5.7 - 10.x.
+
+Please keep in mind that the PHPUnit Polyfills provide _forward_-compatibility.
+This means that features which PHPUnit no longer supports in PHPUnit 10.x, like expecting PHP deprecation notices or warnings, will not be supported in the PHPUnit Polyfills 2.x series.
+
+Please refer to the [PHPUnit 10 release notification] and [PHPUnit 10 changelog] to inform your decision on whether or not to upgrade (yet).
+
+[PHPUnit 10 release notification]: https://phpunit.de/announcements/phpunit-10.html
+[PHPUnit 10 changelog]:            https://github.com/sebastianbergmann/phpunit/blob/main/ChangeLog-10.0.md
 
 
 Using this library

--- a/README.md
+++ b/README.md
@@ -763,7 +763,7 @@ if ( defined( '\Yoast\PHPUnitPolyfills\Autoload::VERSION' ) === false
 
 Contributing
 ------------
-Contributions to this project are welcome. Clone the repo, branch off from `develop`, make your changes, commit them and send in a pull request.
+Contributions to this project are welcome. Clone the repo, branch off from the oldest #.x branch the patch applies to, make your changes, commit them and send in a pull request against the correct #.x branch.
 
 If you are unsure whether the changes you are proposing would be welcome, please open an issue first to discuss your proposal.
 

--- a/composer.json
+++ b/composer.json
@@ -44,8 +44,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-main": "1.x-dev",
-            "dev-develop": "1.x-dev"
+            "dev-main": "2.x-dev"
         }
     },
     "scripts": {


### PR DESCRIPTION
### Updates for branch renames

The `develop` branch has been renamed to `1.x` and a new `2.x` branch will be added to hold development for the `2.x` version.

The `main` branch, from now on, will be used as the release branch for PHPUnit Polyfills 2.x.

### README: add section about PHPUnit support

The README for the 2.x version will be updated to reflect the features supported in the 2.x series.

This commit adds a section to the README for the 1.x branch to inform people about which versions of PHPUnit will be supported by which versions of the PHPUnit Polyfills.