### PR TITLE
Modernize: use class resolution

### DIFF
--- a/phpunitpolyfills-autoload.php
+++ b/phpunitpolyfills-autoload.php
@@ -2,6 +2,8 @@
 
 namespace Yoast\PHPUnitPolyfills;
 
+use PHPUnit\Framework\Assert;
+use PHPUnit\Framework\TestCase;
 use PHPUnit\Runner\Version as PHPUnit_Version;
 use PHPUnit_Runner_Version;
 
@@ -128,7 +130,7 @@ if ( \class_exists( 'Yoast\PHPUnitPolyfills\Autoload', false ) === false ) {
 		 * @return void
 		 */
 		public static function loadExpectExceptionObject() {
-			if ( \method_exists( '\PHPUnit\Framework\TestCase', 'expectExceptionObject' ) === false ) {
+			if ( \method_exists( TestCase::class, 'expectExceptionObject' ) === false ) {
 				// PHPUnit < 6.4.0.
 				require_once __DIR__ . '/src/Polyfills/ExpectExceptionObject.php';
 				return;
@@ -145,7 +147,7 @@ if ( \class_exists( 'Yoast\PHPUnitPolyfills\Autoload', false ) === false ) {
 		 * @return void
 		 */
 		public static function loadAssertIsType() {
-			if ( \method_exists( '\PHPUnit\Framework\Assert', 'assertIsArray' ) === false ) {
+			if ( \method_exists( Assert::class, 'assertIsArray' ) === false ) {
 				// PHPUnit < 7.5.0.
 				require_once __DIR__ . '/src/Polyfills/AssertIsType.php';
 				return;
@@ -162,7 +164,7 @@ if ( \class_exists( 'Yoast\PHPUnitPolyfills\Autoload', false ) === false ) {
 		 * @return void
 		 */
 		public static function loadAssertStringContains() {
-			if ( \method_exists( '\PHPUnit\Framework\Assert', 'assertStringContainsString' ) === false ) {
+			if ( \method_exists( Assert::class, 'assertStringContainsString' ) === false ) {
 				// PHPUnit < 7.5.0.
 				require_once __DIR__ . '/src/Polyfills/AssertStringContains.php';
 				return;
@@ -179,7 +181,7 @@ if ( \class_exists( 'Yoast\PHPUnitPolyfills\Autoload', false ) === false ) {
 		 * @return void
 		 */
 		public static function loadAssertEqualsSpecializations() {
-			if ( \method_exists( '\PHPUnit\Framework\Assert', 'assertEqualsWithDelta' ) === false ) {
+			if ( \method_exists( Assert::class, 'assertEqualsWithDelta' ) === false ) {
 				// PHPUnit < 7.5.0.
 				require_once __DIR__ . '/src/Polyfills/AssertEqualsSpecializations.php';
 				return;
@@ -230,7 +232,7 @@ if ( \class_exists( 'Yoast\PHPUnitPolyfills\Autoload', false ) === false ) {
 				\class_alias( 'PHPUnit_Framework_Error_Deprecated', 'PHPUnit\Framework\Error\Deprecated' );
 			}
 
-			if ( \method_exists( '\PHPUnit\Framework\TestCase', 'expectErrorMessage' ) === false ) {
+			if ( \method_exists( TestCase::class, 'expectErrorMessage' ) === false ) {
 				// PHPUnit < 8.4.0.
 				require_once __DIR__ . '/src/Polyfills/ExpectPHPException.php';
 				return;
@@ -247,7 +249,7 @@ if ( \class_exists( 'Yoast\PHPUnitPolyfills\Autoload', false ) === false ) {
 		 * @return void
 		 */
 		public static function loadExpectExceptionMessageMatches() {
-			if ( \method_exists( '\PHPUnit\Framework\TestCase', 'expectExceptionMessageMatches' ) === false ) {
+			if ( \method_exists( TestCase::class, 'expectExceptionMessageMatches' ) === false ) {
 				// PHPUnit < 8.4.0.
 				require_once __DIR__ . '/src/Polyfills/ExpectExceptionMessageMatches.php';
 				return;
@@ -264,7 +266,7 @@ if ( \class_exists( 'Yoast\PHPUnitPolyfills\Autoload', false ) === false ) {
 		 * @return void
 		 */
 		public static function loadAssertFileEqualsSpecializations() {
-			if ( \method_exists( '\PHPUnit\Framework\Assert', 'assertFileEqualsIgnoringCase' ) === false ) {
+			if ( \method_exists( Assert::class, 'assertFileEqualsIgnoringCase' ) === false ) {
 				// PHPUnit < 8.5.0.
 				require_once __DIR__ . '/src/Polyfills/AssertFileEqualsSpecializations.php';
 				return;
@@ -281,7 +283,7 @@ if ( \class_exists( 'Yoast\PHPUnitPolyfills\Autoload', false ) === false ) {
 		 * @return void
 		 */
 		public static function loadEqualToSpecializations() {
-			if ( \method_exists( '\PHPUnit\Framework\Assert', 'equalToWithDelta' ) === false ) {
+			if ( \method_exists( Assert::class, 'equalToWithDelta' ) === false ) {
 				// PHPUnit < 9.0.0.
 				require_once __DIR__ . '/src/Polyfills/EqualToSpecializations.php';
 				return;
@@ -298,7 +300,7 @@ if ( \class_exists( 'Yoast\PHPUnitPolyfills\Autoload', false ) === false ) {
 		 * @return void
 		 */
 		public static function loadAssertionRenames() {
-			if ( \method_exists( '\PHPUnit\Framework\Assert', 'assertMatchesRegularExpression' ) === false ) {
+			if ( \method_exists( Assert::class, 'assertMatchesRegularExpression' ) === false ) {
 				// PHPUnit < 9.1.0.
 				require_once __DIR__ . '/src/Polyfills/AssertionRenames.php';
 				return;
@@ -315,7 +317,7 @@ if ( \class_exists( 'Yoast\PHPUnitPolyfills\Autoload', false ) === false ) {
 		 * @return void
 		 */
 		public static function loadAssertClosedResource() {
-			if ( \method_exists( '\PHPUnit\Framework\Assert', 'assertIsClosedResource' ) === false ) {
+			if ( \method_exists( Assert::class, 'assertIsClosedResource' ) === false ) {
 				// PHPUnit < 9.3.0.
 				require_once __DIR__ . '/src/Polyfills/AssertClosedResource.php';
 				return;
@@ -332,7 +334,7 @@ if ( \class_exists( 'Yoast\PHPUnitPolyfills\Autoload', false ) === false ) {
 		 * @return void
 		 */
 		public static function loadAssertObjectEquals() {
-			if ( \method_exists( '\PHPUnit\Framework\Assert', 'assertObjectEquals' ) === false ) {
+			if ( \method_exists( Assert::class, 'assertObjectEquals' ) === false ) {
 				// PHPUnit < 9.4.0.
 				require_once __DIR__ . '/src/Polyfills/AssertObjectEquals.php';
 				return;

--- a/src/Polyfills/AssertClosedResource.php
+++ b/src/Polyfills/AssertClosedResource.php
@@ -25,7 +25,7 @@ trait AssertClosedResource {
 	 * @return void
 	 */
 	public static function assertIsClosedResource( $actual, $message = '' ) {
-		$exporter = \class_exists( 'SebastianBergmann\Exporter\Exporter' ) ? new Exporter() : new Exporter_In_Phar();
+		$exporter = \class_exists( Exporter::class ) ? new Exporter() : new Exporter_In_Phar();
 		$msg      = \sprintf( 'Failed asserting that %s is of type "resource (closed)"', $exporter->export( $actual ) );
 
 		if ( $message !== '' ) {
@@ -44,7 +44,7 @@ trait AssertClosedResource {
 	 * @return void
 	 */
 	public static function assertIsNotClosedResource( $actual, $message = '' ) {
-		$exporter = \class_exists( 'SebastianBergmann\Exporter\Exporter' ) ? new Exporter() : new Exporter_In_Phar();
+		$exporter = \class_exists( Exporter::class ) ? new Exporter() : new Exporter_In_Phar();
 		$type     = $exporter->export( $actual );
 		if ( $type === 'NULL' ) {
 			$type = 'resource (closed)';

--- a/src/Polyfills/ExpectPHPException.php
+++ b/src/Polyfills/ExpectPHPException.php
@@ -2,6 +2,11 @@
 
 namespace Yoast\PHPUnitPolyfills\Polyfills;
 
+use PHPUnit\Framework\Error\Deprecated;
+use PHPUnit\Framework\Error\Error;
+use PHPUnit\Framework\Error\Notice;
+use PHPUnit\Framework\Error\Warning;
+
 /**
  * Polyfill the `TestCase::expectDeprecation*()`, `TestCase::expectNotice*()`,
  * `TestCase::expectWarning*()` and `TestCase::expectError*()` methods
@@ -23,7 +28,7 @@ trait ExpectPHPException {
 	 * @return void
 	 */
 	public function expectDeprecation() {
-		$this->expectException( '\PHPUnit\Framework\Error\Deprecated' );
+		$this->expectException( Deprecated::class );
 	}
 
 	/**
@@ -54,7 +59,7 @@ trait ExpectPHPException {
 	 * @return void
 	 */
 	public function expectNotice() {
-		$this->expectException( '\PHPUnit\Framework\Error\Notice' );
+		$this->expectException( Notice::class );
 	}
 
 	/**
@@ -85,7 +90,7 @@ trait ExpectPHPException {
 	 * @return void
 	 */
 	public function expectWarning() {
-		$this->expectException( '\PHPUnit\Framework\Error\Warning' );
+		$this->expectException( Warning::class );
 	}
 
 	/**
@@ -116,7 +121,7 @@ trait ExpectPHPException {
 	 * @return void
 	 */
 	public function expectError() {
-		$this->expectException( '\PHPUnit\Framework\Error\Error' );
+		$this->expectException( Error::class );
 	}
 
 	/**

--- a/tests/Helpers/AssertAttributesHelperTest.php
+++ b/tests/Helpers/AssertAttributesHelperTest.php
@@ -2,6 +2,7 @@
 
 namespace Yoast\PHPUnitPolyfills\Tests\Helpers;
 
+use ReflectionException;
 use Yoast\PHPUnitPolyfills\TestCases\TestCase;
 use Yoast\PHPUnitPolyfills\Tests\Helpers\Fixtures\ClassWithProperties;
 
@@ -65,7 +66,7 @@ final class AssertAttributesHelperTest extends TestCase {
 	 * @return void
 	 */
 	public function testOriginalStateDynamicProperty() {
-		$this->expectException( '\ReflectionException' );
+		$this->expectException( ReflectionException::class );
 
 		$this->getPropertyValue( $this->instance, 'dynamic' );
 	}
@@ -112,10 +113,7 @@ final class AssertAttributesHelperTest extends TestCase {
 	public function testPropertyValueOnceSetDynamicProperty() {
 		$this->instance->setProperties();
 
-		$this->assertInstanceOf(
-			'\Yoast\PHPUnitPolyfills\Tests\Helpers\Fixtures\ClassWithProperties',
-			$this->getPropertyValue( $this->instance, 'dynamic' )
-		);
+		$this->assertInstanceOf( ClassWithProperties::class, $this->getPropertyValue( $this->instance, 'dynamic' ) );
 		$this->assertFalse( $this->getProperty( $this->instance, 'dynamic' )->isDefault() );
 	}
 }

--- a/tests/Polyfills/AssertClosedResourceNotResourceTest.php
+++ b/tests/Polyfills/AssertClosedResourceNotResourceTest.php
@@ -2,7 +2,9 @@
 
 namespace Yoast\PHPUnitPolyfills\Tests\Polyfills;
 
+use PHPUnit\Framework\AssertionFailedError;
 use PHPUnit\Framework\TestCase;
+use PHPUnit_Framework_AssertionFailedError;
 use stdClass;
 use Yoast\PHPUnitPolyfills\Polyfills\AssertClosedResource;
 use Yoast\PHPUnitPolyfills\Polyfills\ExpectExceptionMessageMatches;
@@ -122,10 +124,10 @@ final class AssertClosedResourceNotResourceTest extends TestCase {
 	 * @return string
 	 */
 	public function getAssertionFailedExceptionName() {
-		$exception = 'PHPUnit\Framework\AssertionFailedError';
-		if ( \class_exists( 'PHPUnit_Framework_AssertionFailedError' ) ) {
+		$exception = AssertionFailedError::class;
+		if ( \class_exists( PHPUnit_Framework_AssertionFailedError::class ) ) {
 			// PHPUnit < 6.
-			$exception = 'PHPUnit_Framework_AssertionFailedError';
+			$exception = PHPUnit_Framework_AssertionFailedError::class;
 		}
 
 		return $exception;

--- a/tests/Polyfills/AssertClosedResourceTestCase.php
+++ b/tests/Polyfills/AssertClosedResourceTestCase.php
@@ -2,7 +2,9 @@
 
 namespace Yoast\PHPUnitPolyfills\Tests\Polyfills;
 
+use PHPUnit\Framework\AssertionFailedError;
 use PHPUnit\Framework\TestCase;
+use PHPUnit_Framework_AssertionFailedError;
 use Yoast\PHPUnitPolyfills\Polyfills\AssertClosedResource;
 use Yoast\PHPUnitPolyfills\Polyfills\ExpectExceptionMessageMatches;
 
@@ -56,10 +58,10 @@ abstract class AssertClosedResourceTestCase extends TestCase {
 	 * @return string
 	 */
 	public function getAssertionFailedExceptionName() {
-		$exception = 'PHPUnit\Framework\AssertionFailedError';
-		if ( \class_exists( 'PHPUnit_Framework_AssertionFailedError' ) ) {
+		$exception = AssertionFailedError::class;
+		if ( \class_exists( PHPUnit_Framework_AssertionFailedError::class ) ) {
 			// PHPUnit < 6.
-			$exception = 'PHPUnit_Framework_AssertionFailedError';
+			$exception = PHPUnit_Framework_AssertionFailedError::class;
 		}
 
 		return $exception;

--- a/tests/Polyfills/AssertObjectEqualsPHPUnitLt940Test.php
+++ b/tests/Polyfills/AssertObjectEqualsPHPUnitLt940Test.php
@@ -2,9 +2,13 @@
 
 namespace Yoast\PHPUnitPolyfills\Tests\Polyfills;
 
+use PHPUnit\Framework\AssertionFailedError;
 use PHPUnit\Framework\TestCase;
 use PHPUnit\Runner\Version as PHPUnit_Version;
+use PHPUnit_Framework_AssertionFailedError;
 use stdClass;
+use TypeError;
+use Yoast\PHPUnitPolyfills\Exceptions\InvalidComparisonMethodException;
 use Yoast\PHPUnitPolyfills\Polyfills\AssertObjectEquals;
 use Yoast\PHPUnitPolyfills\Polyfills\ExpectExceptionMessageMatches;
 use Yoast\PHPUnitPolyfills\Tests\Polyfills\Fixtures\ValueObjectNoReturnType;
@@ -35,7 +39,7 @@ final class AssertObjectEqualsPHPUnitLt940Test extends TestCase {
 	 *
 	 * @var string
 	 */
-	const COMPARATOR_EXCEPTION = 'Yoast\PHPUnitPolyfills\Exceptions\InvalidComparisonMethodException';
+	const COMPARATOR_EXCEPTION = InvalidComparisonMethodException::class;
 
 	/**
 	 * Check if these tests can run.
@@ -84,7 +88,7 @@ final class AssertObjectEqualsPHPUnitLt940Test extends TestCase {
 	public function testAssertObjectEqualsFailsOnExpectedNotObject() {
 		$pattern = '`^Argument 1 passed to [^\s]*assertObjectEquals\(\) must be an object, string given`';
 
-		$this->expectException( 'TypeError' );
+		$this->expectException( TypeError::class );
 		$this->expectExceptionMessageMatches( $pattern );
 
 		$actual = new ValueObjectNoReturnType( 'test' );
@@ -99,7 +103,7 @@ final class AssertObjectEqualsPHPUnitLt940Test extends TestCase {
 	public function testAssertObjectEqualsFailsOnActualNotObject() {
 		$pattern = '`^Argument 2 passed to [^\s]*assertObjectEquals\(\) must be an object, string given`';
 
-		$this->expectException( 'TypeError' );
+		$this->expectException( TypeError::class );
 		$this->expectExceptionMessageMatches( $pattern );
 
 		$expected = new ValueObjectNoReturnType( 'test' );
@@ -115,7 +119,7 @@ final class AssertObjectEqualsPHPUnitLt940Test extends TestCase {
 	public function testAssertObjectEqualsFailsOnMethodNotJuggleableToString() {
 		$pattern = '`^Argument 3 passed to [^\s]*assertObjectEquals\(\) must be of the type string, array given`';
 
-		$this->expectException( 'TypeError' );
+		$this->expectException( TypeError::class );
 		$this->expectExceptionMessageMatches( $pattern );
 
 		$expected = new ValueObjectNoReturnType( 'test' );
@@ -318,10 +322,10 @@ final class AssertObjectEqualsPHPUnitLt940Test extends TestCase {
 	 * @return string
 	 */
 	public function getAssertionFailedExceptionName() {
-		$exception = 'PHPUnit\Framework\AssertionFailedError';
-		if ( \class_exists( 'PHPUnit_Framework_AssertionFailedError' ) ) {
+		$exception = AssertionFailedError::class;
+		if ( \class_exists( PHPUnit_Framework_AssertionFailedError::class ) ) {
 			// PHPUnit < 6.
-			$exception = 'PHPUnit_Framework_AssertionFailedError';
+			$exception = PHPUnit_Framework_AssertionFailedError::class;
 		}
 
 		return $exception;

--- a/tests/Polyfills/AssertObjectEqualsTest.php
+++ b/tests/Polyfills/AssertObjectEqualsTest.php
@@ -2,9 +2,18 @@
 
 namespace Yoast\PHPUnitPolyfills\Tests\Polyfills;
 
+use PHPUnit\Framework\AssertionFailedError;
+use PHPUnit\Framework\ComparisonMethodDoesNotAcceptParameterTypeException;
+use PHPUnit\Framework\ComparisonMethodDoesNotDeclareBoolReturnTypeException;
+use PHPUnit\Framework\ComparisonMethodDoesNotDeclareExactlyOneParameterException;
+use PHPUnit\Framework\ComparisonMethodDoesNotDeclareParameterTypeException;
+use PHPUnit\Framework\ComparisonMethodDoesNotExistException;
 use PHPUnit\Framework\TestCase;
 use PHPUnit\Runner\Version as PHPUnit_Version;
+use PHPUnit_Framework_AssertionFailedError;
 use stdClass;
+use TypeError;
+use Yoast\PHPUnitPolyfills\Exceptions\InvalidComparisonMethodException;
 use Yoast\PHPUnitPolyfills\Polyfills\AssertObjectEquals;
 use Yoast\PHPUnitPolyfills\Polyfills\ExpectExceptionMessageMatches;
 use Yoast\PHPUnitPolyfills\Tests\Polyfills\Fixtures\ChildValueObject;
@@ -35,7 +44,7 @@ final class AssertObjectEqualsTest extends TestCase {
 	 *
 	 * @var string
 	 */
-	const COMPARATOR_EXCEPTION = 'Yoast\PHPUnitPolyfills\Exceptions\InvalidComparisonMethodException';
+	const COMPARATOR_EXCEPTION = InvalidComparisonMethodException::class;
 
 	/**
 	 * Verify availability of the assertObjectEquals() method.
@@ -87,7 +96,7 @@ final class AssertObjectEqualsTest extends TestCase {
 	 * @return void
 	 */
 	public function testAssertObjectEqualsFailsOnExpectedNotObject() {
-		$this->expectException( 'TypeError' );
+		$this->expectException( TypeError::class );
 
 		if ( \PHP_VERSION_ID >= 80000
 			&& \version_compare( PHPUnit_Version::id(), '9.4.0', '>=' )
@@ -111,7 +120,7 @@ final class AssertObjectEqualsTest extends TestCase {
 	 * @return void
 	 */
 	public function testAssertObjectEqualsFailsOnActualNotObject() {
-		$this->expectException( 'TypeError' );
+		$this->expectException( TypeError::class );
 
 		if ( \PHP_VERSION_ID >= 80000
 			&& \version_compare( PHPUnit_Version::id(), '9.4.0', '>=' )
@@ -136,7 +145,7 @@ final class AssertObjectEqualsTest extends TestCase {
 	 * @return void
 	 */
 	public function testAssertObjectEqualsFailsOnMethodNotJuggleableToString() {
-		$this->expectException( 'TypeError' );
+		$this->expectException( TypeError::class );
 
 		if ( \PHP_VERSION_ID >= 80000
 			&& \version_compare( PHPUnit_Version::id(), '9.4.0', '>=' )
@@ -165,9 +174,9 @@ final class AssertObjectEqualsTest extends TestCase {
 		$msg = 'Comparison method Yoast\PHPUnitPolyfills\Tests\Polyfills\Fixtures\ValueObject::doesNotExist() does not exist.';
 
 		$exception = self::COMPARATOR_EXCEPTION;
-		if ( \class_exists( 'PHPUnit\Framework\ComparisonMethodDoesNotExistException' ) ) {
+		if ( \class_exists( ComparisonMethodDoesNotExistException::class ) ) {
 			// PHPUnit > 9.4.0.
-			$exception = 'PHPUnit\Framework\ComparisonMethodDoesNotExistException';
+			$exception = ComparisonMethodDoesNotExistException::class;
 		}
 
 		$this->expectException( $exception );
@@ -187,9 +196,9 @@ final class AssertObjectEqualsTest extends TestCase {
 		$msg = 'Comparison method Yoast\PHPUnitPolyfills\Tests\Polyfills\Fixtures\ValueObject::equalsTwoParams() does not declare exactly one parameter.';
 
 		$exception = self::COMPARATOR_EXCEPTION;
-		if ( \class_exists( 'PHPUnit\Framework\ComparisonMethodDoesNotDeclareExactlyOneParameterException' ) ) {
+		if ( \class_exists( ComparisonMethodDoesNotDeclareExactlyOneParameterException::class ) ) {
 			// PHPUnit > 9.4.0.
-			$exception = 'PHPUnit\Framework\ComparisonMethodDoesNotDeclareExactlyOneParameterException';
+			$exception = ComparisonMethodDoesNotDeclareExactlyOneParameterException::class;
 		}
 
 		$this->expectException( $exception );
@@ -209,9 +218,9 @@ final class AssertObjectEqualsTest extends TestCase {
 		$msg = 'Comparison method Yoast\PHPUnitPolyfills\Tests\Polyfills\Fixtures\ValueObject::equalsParamNotRequired() does not declare exactly one parameter.';
 
 		$exception = self::COMPARATOR_EXCEPTION;
-		if ( \class_exists( 'PHPUnit\Framework\ComparisonMethodDoesNotDeclareExactlyOneParameterException' ) ) {
+		if ( \class_exists( ComparisonMethodDoesNotDeclareExactlyOneParameterException::class ) ) {
 			// PHPUnit > 9.4.0.
-			$exception = 'PHPUnit\Framework\ComparisonMethodDoesNotDeclareExactlyOneParameterException';
+			$exception = ComparisonMethodDoesNotDeclareExactlyOneParameterException::class;
 		}
 
 		$this->expectException( $exception );
@@ -232,9 +241,9 @@ final class AssertObjectEqualsTest extends TestCase {
 		$msg = 'Parameter of comparison method Yoast\PHPUnitPolyfills\Tests\Polyfills\Fixtures\ValueObject::equalsParamNoType() does not have a declared type.';
 
 		$exception = self::COMPARATOR_EXCEPTION;
-		if ( \class_exists( 'PHPUnit\Framework\ComparisonMethodDoesNotDeclareParameterTypeException' ) ) {
+		if ( \class_exists( ComparisonMethodDoesNotDeclareParameterTypeException::class ) ) {
 			// PHPUnit > 9.4.0.
-			$exception = 'PHPUnit\Framework\ComparisonMethodDoesNotDeclareParameterTypeException';
+			$exception = ComparisonMethodDoesNotDeclareParameterTypeException::class;
 		}
 
 		$this->expectException( $exception );
@@ -257,9 +266,9 @@ final class AssertObjectEqualsTest extends TestCase {
 		$msg = 'Parameter of comparison method Yoast\PHPUnitPolyfills\Tests\Polyfills\Fixtures\ValueObjectUnion::equalsParamUnionType() does not have a declared type.';
 
 		$exception = self::COMPARATOR_EXCEPTION;
-		if ( \class_exists( 'PHPUnit\Framework\ComparisonMethodDoesNotDeclareParameterTypeException' ) ) {
+		if ( \class_exists( ComparisonMethodDoesNotDeclareParameterTypeException::class ) ) {
 			// PHPUnit > 9.4.0.
-			$exception = 'PHPUnit\Framework\ComparisonMethodDoesNotDeclareParameterTypeException';
+			$exception = ComparisonMethodDoesNotDeclareParameterTypeException::class;
 		}
 
 		$this->expectException( $exception );
@@ -280,9 +289,9 @@ final class AssertObjectEqualsTest extends TestCase {
 		$msg = 'is not an accepted argument type for comparison method Yoast\PHPUnitPolyfills\Tests\Polyfills\Fixtures\ValueObject::equalsParamNonClassType().';
 
 		$exception = self::COMPARATOR_EXCEPTION;
-		if ( \class_exists( 'PHPUnit\Framework\ComparisonMethodDoesNotAcceptParameterTypeException' ) ) {
+		if ( \class_exists( ComparisonMethodDoesNotAcceptParameterTypeException::class ) ) {
 			// PHPUnit > 9.4.0.
-			$exception = 'PHPUnit\Framework\ComparisonMethodDoesNotAcceptParameterTypeException';
+			$exception = ComparisonMethodDoesNotAcceptParameterTypeException::class;
 		}
 
 		$this->expectException( $exception );
@@ -303,9 +312,9 @@ final class AssertObjectEqualsTest extends TestCase {
 		$msg = 'is not an accepted argument type for comparison method Yoast\PHPUnitPolyfills\Tests\Polyfills\Fixtures\ValueObject::equalsParamNonExistentClassType().';
 
 		$exception = self::COMPARATOR_EXCEPTION;
-		if ( \class_exists( 'PHPUnit\Framework\ComparisonMethodDoesNotAcceptParameterTypeException' ) ) {
+		if ( \class_exists( ComparisonMethodDoesNotAcceptParameterTypeException::class ) ) {
 			// PHPUnit > 9.4.0.
-			$exception = 'PHPUnit\Framework\ComparisonMethodDoesNotAcceptParameterTypeException';
+			$exception = ComparisonMethodDoesNotAcceptParameterTypeException::class;
 		}
 
 		$this->expectException( $exception );
@@ -326,9 +335,9 @@ final class AssertObjectEqualsTest extends TestCase {
 		$msg = 'is not an accepted argument type for comparison method Yoast\PHPUnitPolyfills\Tests\Polyfills\Fixtures\ValueObject::equals().';
 
 		$exception = self::COMPARATOR_EXCEPTION;
-		if ( \class_exists( 'PHPUnit\Framework\ComparisonMethodDoesNotAcceptParameterTypeException' ) ) {
+		if ( \class_exists( ComparisonMethodDoesNotAcceptParameterTypeException::class ) ) {
 			// PHPUnit > 9.4.0.
-			$exception = 'PHPUnit\Framework\ComparisonMethodDoesNotAcceptParameterTypeException';
+			$exception = ComparisonMethodDoesNotAcceptParameterTypeException::class;
 		}
 
 		$this->expectException( $exception );
@@ -348,10 +357,10 @@ final class AssertObjectEqualsTest extends TestCase {
 		$msg = 'Comparison method Yoast\PHPUnitPolyfills\Tests\Polyfills\Fixtures\ValueObject::equalsNonBooleanReturnType() does not return a boolean value.';
 
 		$exception = self::COMPARATOR_EXCEPTION;
-		if ( \class_exists( 'PHPUnit\Framework\ComparisonMethodDoesNotDeclareBoolReturnTypeException' ) ) {
+		if ( \class_exists( ComparisonMethodDoesNotDeclareBoolReturnTypeException::class ) ) {
 			// PHPUnit > 9.4.0.
 			$msg       = 'Comparison method Yoast\PHPUnitPolyfills\Tests\Polyfills\Fixtures\ValueObject::equalsNonBooleanReturnType() does not declare bool return type.';
-			$exception = 'PHPUnit\Framework\ComparisonMethodDoesNotDeclareBoolReturnTypeException';
+			$exception = ComparisonMethodDoesNotDeclareBoolReturnTypeException::class;
 		}
 
 		$this->expectException( $exception );
@@ -402,10 +411,10 @@ final class AssertObjectEqualsTest extends TestCase {
 	 * @return string
 	 */
 	public function getAssertionFailedExceptionName() {
-		$exception = 'PHPUnit\Framework\AssertionFailedError';
-		if ( \class_exists( 'PHPUnit_Framework_AssertionFailedError' ) ) {
+		$exception = AssertionFailedError::class;
+		if ( \class_exists( PHPUnit_Framework_AssertionFailedError::class ) ) {
 			// PHPUnit < 6.
-			$exception = 'PHPUnit_Framework_AssertionFailedError';
+			$exception = PHPUnit_Framework_AssertionFailedError::class;
 		}
 
 		return $exception;

--- a/tests/Polyfills/AssertStringContainsTest.php
+++ b/tests/Polyfills/AssertStringContainsTest.php
@@ -2,7 +2,9 @@
 
 namespace Yoast\PHPUnitPolyfills\Tests\Polyfills;
 
+use PHPUnit\Framework\AssertionFailedError;
 use PHPUnit\Framework\TestCase;
+use PHPUnit_Framework_AssertionFailedError;
 use Yoast\PHPUnitPolyfills\Polyfills\AssertStringContains;
 use Yoast\PHPUnitPolyfills\Polyfills\ExpectExceptionMessageMatches;
 
@@ -181,10 +183,10 @@ final class AssertStringContainsTest extends TestCase {
 	 * @return string
 	 */
 	public function getAssertionFailedExceptionName() {
-		$exception = 'PHPUnit\Framework\AssertionFailedError';
-		if ( \class_exists( 'PHPUnit_Framework_AssertionFailedError' ) ) {
+		$exception = AssertionFailedError::class;
+		if ( \class_exists( PHPUnit_Framework_AssertionFailedError::class ) ) {
 			// PHPUnit < 6.
-			$exception = 'PHPUnit_Framework_AssertionFailedError';
+			$exception = PHPUnit_Framework_AssertionFailedError::class;
 		}
 
 		return $exception;

--- a/tests/Polyfills/ExpectExceptionMessageMatchesTest.php
+++ b/tests/Polyfills/ExpectExceptionMessageMatchesTest.php
@@ -23,7 +23,7 @@ final class ExpectExceptionMessageMatchesTest extends TestCase {
 	 * @throws Exception For testing purposes.
 	 */
 	public function testExpectExceptionMessageMatches() {
-		$this->expectException( '\Exception' ); // Needed for PHPUnit 5.x.
+		$this->expectException( Exception::class ); // Needed for PHPUnit 5.x.
 		$this->expectExceptionMessageMatches( '`^a poly[a-z]+ [a-zA-Z0-9_]+ me(s){2}age$`i' );
 
 		throw new Exception( 'A polymorphic exception message' );

--- a/tests/TestCases/TestCaseTestTrait.php
+++ b/tests/TestCases/TestCaseTestTrait.php
@@ -84,7 +84,7 @@ trait TestCaseTestTrait {
 	 * @throws Exception For testing purposes.
 	 */
 	public function testAvailabilityExpectExceptionMessageMatchesTrait() {
-		$this->expectException( '\Exception' );
+		$this->expectException( Exception::class );
 		$this->expectExceptionMessageMatches( '`^a poly[a-z]+ [a-zA-Z0-9_]+ me(s){2}age$`i' );
 
 		throw new Exception( 'A polymorphic exception message' );


### PR DESCRIPTION
... which is available since PHP 5.5 and can be used now support for PHP < 5.6 has been dropped.