### PR TITLE
PHPUnit 10 | Make all assertion/exception methods `final`

### DIFF
--- a/src/Helpers/AssertAttributeHelper.php
+++ b/src/Helpers/AssertAttributeHelper.php
@@ -46,7 +46,7 @@ trait AssertAttributeHelper {
 	 *
 	 * @throws ReflectionException When a non-existent property is requested.
 	 */
-	public static function getProperty( $objInstance, $propertyName ) {
+	final public static function getProperty( $objInstance, $propertyName ) {
 		$reflect  = new ReflectionObject( $objInstance );
 		$property = $reflect->getProperty( $propertyName );
 		$property->setAccessible( true );
@@ -62,7 +62,7 @@ trait AssertAttributeHelper {
 	 *
 	 * @return mixed
 	 */
-	public static function getPropertyValue( $objInstance, $propertyName ) {
+	final public static function getPropertyValue( $objInstance, $propertyName ) {
 		$property = static::getProperty( $objInstance, $propertyName );
 
 		return $property->getValue( $objInstance );

--- a/src/Polyfills/AssertEqualsSpecializations.php
+++ b/src/Polyfills/AssertEqualsSpecializations.php
@@ -24,7 +24,7 @@ trait AssertEqualsSpecializations {
 	 *
 	 * @return void
 	 */
-	public static function assertEqualsCanonicalizing( $expected, $actual, $message = '' ) {
+	final public static function assertEqualsCanonicalizing( $expected, $actual, $message = '' ) {
 		static::assertEquals( $expected, $actual, $message, 0.0, 10, true );
 	}
 
@@ -37,7 +37,7 @@ trait AssertEqualsSpecializations {
 	 *
 	 * @return void
 	 */
-	public static function assertEqualsIgnoringCase( $expected, $actual, $message = '' ) {
+	final public static function assertEqualsIgnoringCase( $expected, $actual, $message = '' ) {
 		static::assertEquals( $expected, $actual, $message, 0.0, 10, false, true );
 	}
 
@@ -51,7 +51,7 @@ trait AssertEqualsSpecializations {
 	 *
 	 * @return void
 	 */
-	public static function assertEqualsWithDelta( $expected, $actual, $delta, $message = '' ) {
+	final public static function assertEqualsWithDelta( $expected, $actual, $delta, $message = '' ) {
 		static::assertEquals( $expected, $actual, $message, $delta );
 	}
 
@@ -64,7 +64,7 @@ trait AssertEqualsSpecializations {
 	 *
 	 * @return void
 	 */
-	public static function assertNotEqualsCanonicalizing( $expected, $actual, $message = '' ) {
+	final public static function assertNotEqualsCanonicalizing( $expected, $actual, $message = '' ) {
 		static::assertNotEquals( $expected, $actual, $message, 0.0, 10, true );
 	}
 
@@ -77,7 +77,7 @@ trait AssertEqualsSpecializations {
 	 *
 	 * @return void
 	 */
-	public static function assertNotEqualsIgnoringCase( $expected, $actual, $message = '' ) {
+	final public static function assertNotEqualsIgnoringCase( $expected, $actual, $message = '' ) {
 		static::assertNotEquals( $expected, $actual, $message, 0.0, 10, false, true );
 	}
 
@@ -91,7 +91,7 @@ trait AssertEqualsSpecializations {
 	 *
 	 * @return void
 	 */
-	public static function assertNotEqualsWithDelta( $expected, $actual, $delta, $message = '' ) {
+	final public static function assertNotEqualsWithDelta( $expected, $actual, $delta, $message = '' ) {
 		static::assertNotEquals( $expected, $actual, $message, $delta );
 	}
 }

--- a/src/Polyfills/AssertFileEqualsSpecializations.php
+++ b/src/Polyfills/AssertFileEqualsSpecializations.php
@@ -28,7 +28,7 @@ trait AssertFileEqualsSpecializations {
 	 *
 	 * @return void
 	 */
-	public static function assertFileEqualsCanonicalizing( $expected, $actual, $message = '' ) {
+	final public static function assertFileEqualsCanonicalizing( $expected, $actual, $message = '' ) {
 		static::assertFileEquals( $expected, $actual, $message, true );
 	}
 
@@ -42,7 +42,7 @@ trait AssertFileEqualsSpecializations {
 	 *
 	 * @return void
 	 */
-	public static function assertFileEqualsIgnoringCase( $expected, $actual, $message = '' ) {
+	final public static function assertFileEqualsIgnoringCase( $expected, $actual, $message = '' ) {
 		static::assertFileEquals( $expected, $actual, $message, false, true );
 	}
 
@@ -56,7 +56,7 @@ trait AssertFileEqualsSpecializations {
 	 *
 	 * @return void
 	 */
-	public static function assertFileNotEqualsCanonicalizing( $expected, $actual, $message = '' ) {
+	final public static function assertFileNotEqualsCanonicalizing( $expected, $actual, $message = '' ) {
 		static::assertFileNotEquals( $expected, $actual, $message, true );
 	}
 
@@ -70,7 +70,7 @@ trait AssertFileEqualsSpecializations {
 	 *
 	 * @return void
 	 */
-	public static function assertFileNotEqualsIgnoringCase( $expected, $actual, $message = '' ) {
+	final public static function assertFileNotEqualsIgnoringCase( $expected, $actual, $message = '' ) {
 		static::assertFileNotEquals( $expected, $actual, $message, false, true );
 	}
 
@@ -84,7 +84,7 @@ trait AssertFileEqualsSpecializations {
 	 *
 	 * @return void
 	 */
-	public static function assertStringEqualsFileCanonicalizing( $expectedFile, $actualString, $message = '' ) {
+	final public static function assertStringEqualsFileCanonicalizing( $expectedFile, $actualString, $message = '' ) {
 		static::assertStringEqualsFile( $expectedFile, $actualString, $message, true );
 	}
 
@@ -98,7 +98,7 @@ trait AssertFileEqualsSpecializations {
 	 *
 	 * @return void
 	 */
-	public static function assertStringEqualsFileIgnoringCase( $expectedFile, $actualString, $message = '' ) {
+	final public static function assertStringEqualsFileIgnoringCase( $expectedFile, $actualString, $message = '' ) {
 		static::assertStringEqualsFile( $expectedFile, $actualString, $message, false, true );
 	}
 
@@ -112,7 +112,7 @@ trait AssertFileEqualsSpecializations {
 	 *
 	 * @return void
 	 */
-	public static function assertStringNotEqualsFileCanonicalizing( $expectedFile, $actualString, $message = '' ) {
+	final public static function assertStringNotEqualsFileCanonicalizing( $expectedFile, $actualString, $message = '' ) {
 		static::assertStringNotEqualsFile( $expectedFile, $actualString, $message, true );
 	}
 
@@ -126,7 +126,7 @@ trait AssertFileEqualsSpecializations {
 	 *
 	 * @return void
 	 */
-	public static function assertStringNotEqualsFileIgnoringCase( $expectedFile, $actualString, $message = '' ) {
+	final public static function assertStringNotEqualsFileIgnoringCase( $expectedFile, $actualString, $message = '' ) {
 		static::assertStringNotEqualsFile( $expectedFile, $actualString, $message, false, true );
 	}
 }

--- a/src/Polyfills/AssertIsType.php
+++ b/src/Polyfills/AssertIsType.php
@@ -25,7 +25,7 @@ trait AssertIsType {
 	 *
 	 * @return void
 	 */
-	public static function assertIsArray( $actual, $message = '' ) {
+	final public static function assertIsArray( $actual, $message = '' ) {
 		static::assertInternalType( 'array', $actual, $message );
 	}
 
@@ -37,7 +37,7 @@ trait AssertIsType {
 	 *
 	 * @return void
 	 */
-	public static function assertIsBool( $actual, $message = '' ) {
+	final public static function assertIsBool( $actual, $message = '' ) {
 		static::assertInternalType( 'bool', $actual, $message );
 	}
 
@@ -49,7 +49,7 @@ trait AssertIsType {
 	 *
 	 * @return void
 	 */
-	public static function assertIsFloat( $actual, $message = '' ) {
+	final public static function assertIsFloat( $actual, $message = '' ) {
 		static::assertInternalType( 'float', $actual, $message );
 	}
 
@@ -61,7 +61,7 @@ trait AssertIsType {
 	 *
 	 * @return void
 	 */
-	public static function assertIsInt( $actual, $message = '' ) {
+	final public static function assertIsInt( $actual, $message = '' ) {
 		static::assertInternalType( 'int', $actual, $message );
 	}
 
@@ -73,7 +73,7 @@ trait AssertIsType {
 	 *
 	 * @return void
 	 */
-	public static function assertIsNumeric( $actual, $message = '' ) {
+	final public static function assertIsNumeric( $actual, $message = '' ) {
 		static::assertInternalType( 'numeric', $actual, $message );
 	}
 
@@ -85,7 +85,7 @@ trait AssertIsType {
 	 *
 	 * @return void
 	 */
-	public static function assertIsObject( $actual, $message = '' ) {
+	final public static function assertIsObject( $actual, $message = '' ) {
 		static::assertInternalType( 'object', $actual, $message );
 	}
 
@@ -97,7 +97,7 @@ trait AssertIsType {
 	 *
 	 * @return void
 	 */
-	public static function assertIsResource( $actual, $message = '' ) {
+	final public static function assertIsResource( $actual, $message = '' ) {
 		static::assertInternalType( 'resource', $actual, $message );
 	}
 
@@ -109,7 +109,7 @@ trait AssertIsType {
 	 *
 	 * @return void
 	 */
-	public static function assertIsString( $actual, $message = '' ) {
+	final public static function assertIsString( $actual, $message = '' ) {
 		static::assertInternalType( 'string', $actual, $message );
 	}
 
@@ -121,7 +121,7 @@ trait AssertIsType {
 	 *
 	 * @return void
 	 */
-	public static function assertIsScalar( $actual, $message = '' ) {
+	final public static function assertIsScalar( $actual, $message = '' ) {
 		static::assertInternalType( 'scalar', $actual, $message );
 	}
 
@@ -133,7 +133,7 @@ trait AssertIsType {
 	 *
 	 * @return void
 	 */
-	public static function assertIsCallable( $actual, $message = '' ) {
+	final public static function assertIsCallable( $actual, $message = '' ) {
 		static::assertInternalType( 'callable', $actual, $message );
 	}
 
@@ -152,7 +152,7 @@ trait AssertIsType {
 	 *
 	 * @return void
 	 */
-	public static function assertIsIterable( $actual, $message = '' ) {
+	final public static function assertIsIterable( $actual, $message = '' ) {
 		if ( \function_exists( 'is_iterable' ) === true ) {
 			// PHP >= 7.1.
 			// phpcs:ignore PHPCompatibility.FunctionUse.NewFunctions.is_iterableFound
@@ -173,7 +173,7 @@ trait AssertIsType {
 	 *
 	 * @return void
 	 */
-	public static function assertIsNotArray( $actual, $message = '' ) {
+	final public static function assertIsNotArray( $actual, $message = '' ) {
 		static::assertNotInternalType( 'array', $actual, $message );
 	}
 
@@ -185,7 +185,7 @@ trait AssertIsType {
 	 *
 	 * @return void
 	 */
-	public static function assertIsNotBool( $actual, $message = '' ) {
+	final public static function assertIsNotBool( $actual, $message = '' ) {
 		static::assertNotInternalType( 'bool', $actual, $message );
 	}
 
@@ -197,7 +197,7 @@ trait AssertIsType {
 	 *
 	 * @return void
 	 */
-	public static function assertIsNotFloat( $actual, $message = '' ) {
+	final public static function assertIsNotFloat( $actual, $message = '' ) {
 		static::assertNotInternalType( 'float', $actual, $message );
 	}
 
@@ -209,7 +209,7 @@ trait AssertIsType {
 	 *
 	 * @return void
 	 */
-	public static function assertIsNotInt( $actual, $message = '' ) {
+	final public static function assertIsNotInt( $actual, $message = '' ) {
 		static::assertNotInternalType( 'int', $actual, $message );
 	}
 
@@ -221,7 +221,7 @@ trait AssertIsType {
 	 *
 	 * @return void
 	 */
-	public static function assertIsNotNumeric( $actual, $message = '' ) {
+	final public static function assertIsNotNumeric( $actual, $message = '' ) {
 		static::assertNotInternalType( 'numeric', $actual, $message );
 	}
 
@@ -233,7 +233,7 @@ trait AssertIsType {
 	 *
 	 * @return void
 	 */
-	public static function assertIsNotObject( $actual, $message = '' ) {
+	final public static function assertIsNotObject( $actual, $message = '' ) {
 		static::assertNotInternalType( 'object', $actual, $message );
 	}
 
@@ -245,7 +245,7 @@ trait AssertIsType {
 	 *
 	 * @return void
 	 */
-	public static function assertIsNotResource( $actual, $message = '' ) {
+	final public static function assertIsNotResource( $actual, $message = '' ) {
 		static::assertNotInternalType( 'resource', $actual, $message );
 	}
 
@@ -257,7 +257,7 @@ trait AssertIsType {
 	 *
 	 * @return void
 	 */
-	public static function assertIsNotString( $actual, $message = '' ) {
+	final public static function assertIsNotString( $actual, $message = '' ) {
 		static::assertNotInternalType( 'string', $actual, $message );
 	}
 
@@ -269,7 +269,7 @@ trait AssertIsType {
 	 *
 	 * @return void
 	 */
-	public static function assertIsNotScalar( $actual, $message = '' ) {
+	final public static function assertIsNotScalar( $actual, $message = '' ) {
 		static::assertNotInternalType( 'scalar', $actual, $message );
 	}
 
@@ -281,7 +281,7 @@ trait AssertIsType {
 	 *
 	 * @return void
 	 */
-	public static function assertIsNotCallable( $actual, $message = '' ) {
+	final public static function assertIsNotCallable( $actual, $message = '' ) {
 		static::assertNotInternalType( 'callable', $actual, $message );
 	}
 
@@ -300,7 +300,7 @@ trait AssertIsType {
 	 *
 	 * @return void
 	 */
-	public static function assertIsNotIterable( $actual, $message = '' ) {
+	final public static function assertIsNotIterable( $actual, $message = '' ) {
 		if ( \function_exists( 'is_iterable' ) === true ) {
 			// PHP >= 7.1.
 			// phpcs:ignore PHPCompatibility.FunctionUse.NewFunctions.is_iterableFound

--- a/src/Polyfills/AssertObjectEquals.php
+++ b/src/Polyfills/AssertObjectEquals.php
@@ -50,7 +50,7 @@ trait AssertObjectEquals {
 	 * @throws TypeError                        When any of the passed arguments do not meet the required type.
 	 * @throws InvalidComparisonMethodException When the comparator method does not comply with the requirements.
 	 */
-	public static function assertObjectEquals( $expected, $actual, $method = 'equals', $message = '' ) {
+	final public static function assertObjectEquals( $expected, $actual, $method = 'equals', $message = '' ) {
 		/*
 		 * Parameter input validation.
 		 * In PHPUnit this is done via PHP native type declarations. Emulating this for the polyfill.

--- a/src/Polyfills/AssertStringContains.php
+++ b/src/Polyfills/AssertStringContains.php
@@ -31,7 +31,7 @@ trait AssertStringContains {
 	 *
 	 * @return void
 	 */
-	public static function assertStringContainsString( $needle, $haystack, $message = '' ) {
+	final public static function assertStringContainsString( $needle, $haystack, $message = '' ) {
 		if ( $needle === '' ) {
 			static::assertSame( $needle, $needle, $message );
 			return;
@@ -49,7 +49,7 @@ trait AssertStringContains {
 	 *
 	 * @return void
 	 */
-	public static function assertStringContainsStringIgnoringCase( $needle, $haystack, $message = '' ) {
+	final public static function assertStringContainsStringIgnoringCase( $needle, $haystack, $message = '' ) {
 		if ( $needle === '' ) {
 			static::assertSame( $needle, $needle, $message );
 			return;
@@ -67,7 +67,7 @@ trait AssertStringContains {
 	 *
 	 * @return void
 	 */
-	public static function assertStringNotContainsString( $needle, $haystack, $message = '' ) {
+	final public static function assertStringNotContainsString( $needle, $haystack, $message = '' ) {
 		if ( $needle === '' ) {
 			$msg = "Failed asserting that '{$haystack}' does not contain \"\".";
 			if ( $message !== '' ) {
@@ -89,7 +89,7 @@ trait AssertStringContains {
 	 *
 	 * @return void
 	 */
-	public static function assertStringNotContainsStringIgnoringCase( $needle, $haystack, $message = '' ) {
+	final public static function assertStringNotContainsStringIgnoringCase( $needle, $haystack, $message = '' ) {
 		if ( $needle === '' ) {
 			$msg = "Failed asserting that '{$haystack}' does not contain \"\".";
 			if ( $message !== '' ) {

--- a/src/Polyfills/AssertionRenames.php
+++ b/src/Polyfills/AssertionRenames.php
@@ -49,7 +49,7 @@ trait AssertionRenames {
 	 *
 	 * @return void
 	 */
-	public static function assertIsNotReadable( $filename, $message = '' ) {
+	final public static function assertIsNotReadable( $filename, $message = '' ) {
 		static::assertNotIsReadable( $filename, $message );
 	}
 
@@ -61,7 +61,7 @@ trait AssertionRenames {
 	 *
 	 * @return void
 	 */
-	public static function assertIsNotWritable( $filename, $message = '' ) {
+	final public static function assertIsNotWritable( $filename, $message = '' ) {
 		static::assertNotIsWritable( $filename, $message );
 	}
 
@@ -73,7 +73,7 @@ trait AssertionRenames {
 	 *
 	 * @return void
 	 */
-	public static function assertDirectoryDoesNotExist( $directory, $message = '' ) {
+	final public static function assertDirectoryDoesNotExist( $directory, $message = '' ) {
 		static::assertDirectoryNotExists( $directory, $message );
 	}
 
@@ -85,7 +85,7 @@ trait AssertionRenames {
 	 *
 	 * @return void
 	 */
-	public static function assertDirectoryIsNotReadable( $directory, $message = '' ) {
+	final public static function assertDirectoryIsNotReadable( $directory, $message = '' ) {
 		static::assertDirectoryNotIsReadable( $directory, $message );
 	}
 
@@ -97,7 +97,7 @@ trait AssertionRenames {
 	 *
 	 * @return void
 	 */
-	public static function assertDirectoryIsNotWritable( $directory, $message = '' ) {
+	final public static function assertDirectoryIsNotWritable( $directory, $message = '' ) {
 		static::assertDirectoryNotIsWritable( $directory, $message );
 	}
 
@@ -109,7 +109,7 @@ trait AssertionRenames {
 	 *
 	 * @return void
 	 */
-	public static function assertFileDoesNotExist( $filename, $message = '' ) {
+	final public static function assertFileDoesNotExist( $filename, $message = '' ) {
 		static::assertFileNotExists( $filename, $message );
 	}
 
@@ -121,7 +121,7 @@ trait AssertionRenames {
 	 *
 	 * @return void
 	 */
-	public static function assertFileIsNotReadable( $file, $message = '' ) {
+	final public static function assertFileIsNotReadable( $file, $message = '' ) {
 		static::assertFileNotIsReadable( $file, $message );
 	}
 
@@ -133,7 +133,7 @@ trait AssertionRenames {
 	 *
 	 * @return void
 	 */
-	public static function assertFileIsNotWritable( $file, $message = '' ) {
+	final public static function assertFileIsNotWritable( $file, $message = '' ) {
 		static::assertFileNotIsWritable( $file, $message );
 	}
 
@@ -146,7 +146,7 @@ trait AssertionRenames {
 	 *
 	 * @return void
 	 */
-	public static function assertMatchesRegularExpression( $pattern, $string, $message = '' ) {
+	final public static function assertMatchesRegularExpression( $pattern, $string, $message = '' ) {
 		static::assertRegExp( $pattern, $string, $message );
 	}
 
@@ -159,7 +159,7 @@ trait AssertionRenames {
 	 *
 	 * @return void
 	 */
-	public static function assertDoesNotMatchRegularExpression( $pattern, $string, $message = '' ) {
+	final public static function assertDoesNotMatchRegularExpression( $pattern, $string, $message = '' ) {
 		static::assertNotRegExp( $pattern, $string, $message );
 	}
 }

--- a/src/Polyfills/EqualToSpecializations.php
+++ b/src/Polyfills/EqualToSpecializations.php
@@ -24,7 +24,7 @@ trait EqualToSpecializations {
 	 *
 	 * @return IsEqual|PHPUnit_Framework_Constraint_IsEqual An isEqual constraint instance.
 	 */
-	public static function equalToCanonicalizing( $value ) {
+	final public static function equalToCanonicalizing( $value ) {
 		return static::equalTo( $value, 0.0, 10, true, false );
 	}
 
@@ -35,7 +35,7 @@ trait EqualToSpecializations {
 	 *
 	 * @return IsEqual|PHPUnit_Framework_Constraint_IsEqual An isEqual constraint instance.
 	 */
-	public static function equalToIgnoringCase( $value ) {
+	final public static function equalToIgnoringCase( $value ) {
 		return static::equalTo( $value, 0.0, 10, false, true );
 	}
 
@@ -47,7 +47,7 @@ trait EqualToSpecializations {
 	 *
 	 * @return IsEqual|PHPUnit_Framework_Constraint_IsEqual An isEqual constraint instance.
 	 */
-	public static function equalToWithDelta( $value, $delta ) {
+	final public static function equalToWithDelta( $value, $delta ) {
 		return static::equalTo( $value, $delta, 10, false, false );
 	}
 }

--- a/src/Polyfills/ExpectExceptionMessageMatches.php
+++ b/src/Polyfills/ExpectExceptionMessageMatches.php
@@ -23,7 +23,7 @@ trait ExpectExceptionMessageMatches {
 	 *
 	 * @return void
 	 */
-	public function expectExceptionMessageMatches( $regularExpression ) {
+	final public function expectExceptionMessageMatches( $regularExpression ) {
 		$this->expectExceptionMessageRegExp( $regularExpression );
 	}
 }

--- a/src/Polyfills/ExpectExceptionObject.php
+++ b/src/Polyfills/ExpectExceptionObject.php
@@ -20,7 +20,7 @@ trait ExpectExceptionObject {
 	 *
 	 * @return void
 	 */
-	public function expectExceptionObject( Exception $exception ) {
+	final public function expectExceptionObject( Exception $exception ) {
 		$this->expectException( \get_class( $exception ) );
 		$this->expectExceptionMessage( $exception->getMessage() );
 		$this->expectExceptionCode( $exception->getCode() );

--- a/src/Polyfills/ExpectPHPException.php
+++ b/src/Polyfills/ExpectPHPException.php
@@ -27,7 +27,7 @@ trait ExpectPHPException {
 	 *
 	 * @return void
 	 */
-	public function expectDeprecation() {
+	final public function expectDeprecation() {
 		$this->expectException( Deprecated::class );
 	}
 
@@ -38,7 +38,7 @@ trait ExpectPHPException {
 	 *
 	 * @return void
 	 */
-	public function expectDeprecationMessage( $message ) {
+	final public function expectDeprecationMessage( $message ) {
 		$this->expectExceptionMessage( $message );
 	}
 
@@ -49,7 +49,7 @@ trait ExpectPHPException {
 	 *
 	 * @return void
 	 */
-	public function expectDeprecationMessageMatches( $regularExpression ) {
+	final public function expectDeprecationMessageMatches( $regularExpression ) {
 		$this->expectExceptionMessageRegExp( $regularExpression );
 	}
 
@@ -58,7 +58,7 @@ trait ExpectPHPException {
 	 *
 	 * @return void
 	 */
-	public function expectNotice() {
+	final public function expectNotice() {
 		$this->expectException( Notice::class );
 	}
 
@@ -69,7 +69,7 @@ trait ExpectPHPException {
 	 *
 	 * @return void
 	 */
-	public function expectNoticeMessage( $message ) {
+	final public function expectNoticeMessage( $message ) {
 		$this->expectExceptionMessage( $message );
 	}
 
@@ -80,7 +80,7 @@ trait ExpectPHPException {
 	 *
 	 * @return void
 	 */
-	public function expectNoticeMessageMatches( $regularExpression ) {
+	final public function expectNoticeMessageMatches( $regularExpression ) {
 		$this->expectExceptionMessageRegExp( $regularExpression );
 	}
 
@@ -89,7 +89,7 @@ trait ExpectPHPException {
 	 *
 	 * @return void
 	 */
-	public function expectWarning() {
+	final public function expectWarning() {
 		$this->expectException( Warning::class );
 	}
 
@@ -100,7 +100,7 @@ trait ExpectPHPException {
 	 *
 	 * @return void
 	 */
-	public function expectWarningMessage( $message ) {
+	final public function expectWarningMessage( $message ) {
 		$this->expectExceptionMessage( $message );
 	}
 
@@ -111,7 +111,7 @@ trait ExpectPHPException {
 	 *
 	 * @return void
 	 */
-	public function expectWarningMessageMatches( $regularExpression ) {
+	final public function expectWarningMessageMatches( $regularExpression ) {
 		$this->expectExceptionMessageRegExp( $regularExpression );
 	}
 
@@ -120,7 +120,7 @@ trait ExpectPHPException {
 	 *
 	 * @return void
 	 */
-	public function expectError() {
+	final public function expectError() {
 		$this->expectException( Error::class );
 	}
 
@@ -131,7 +131,7 @@ trait ExpectPHPException {
 	 *
 	 * @return void
 	 */
-	public function expectErrorMessage( $message ) {
+	final public function expectErrorMessage( $message ) {
 		$this->expectExceptionMessage( $message );
 	}
 
@@ -142,7 +142,7 @@ trait ExpectPHPException {
 	 *
 	 * @return void
 	 */
-	public function expectErrorMessageMatches( $regularExpression ) {
+	final public function expectErrorMessageMatches( $regularExpression ) {
 		$this->expectExceptionMessageRegExp( $regularExpression );
 	}
 }

--- a/tests/TestCases/TestCaseTestTrait.php
+++ b/tests/TestCases/TestCaseTestTrait.php
@@ -16,7 +16,7 @@ trait TestCaseTestTrait {
 	 *
 	 * @return array[]
 	 */
-	public static function dataHaveFixtureMethodsBeenTriggered() {
+	final public static function dataHaveFixtureMethodsBeenTriggered() {
 		return [
 			[ 1, 1, 0, 1, 0 ],
 			[ 1, 2, 1, 2, 1 ],
@@ -31,7 +31,7 @@ trait TestCaseTestTrait {
 	 *
 	 * @throws Exception For testing purposes.
 	 */
-	public function testAvailabilityExpectExceptionObjectTrait() {
+	final public function testAvailabilityExpectExceptionObjectTrait() {
 		$exception = new Exception( 'message', 101 );
 		$this->expectExceptionObject( $exception );
 
@@ -43,7 +43,7 @@ trait TestCaseTestTrait {
 	 *
 	 * @return void
 	 */
-	public function testAvailabilityAssertIsTypeTrait() {
+	final public function testAvailabilityAssertIsTypeTrait() {
 		self::assertIsInt( self::$beforeClass );
 	}
 
@@ -52,7 +52,7 @@ trait TestCaseTestTrait {
 	 *
 	 * @return void
 	 */
-	public function testAvailabilityAssertStringContainsTrait() {
+	final public function testAvailabilityAssertStringContainsTrait() {
 		$this->assertStringContainsString( 'foo', 'foobar' );
 	}
 
@@ -61,7 +61,7 @@ trait TestCaseTestTrait {
 	 *
 	 * @return void
 	 */
-	public function testAvailabilityAssertEqualsSpecializationsTrait() {
+	final public function testAvailabilityAssertEqualsSpecializationsTrait() {
 		static::assertEqualsIgnoringCase( 'a', 'A' );
 	}
 
@@ -70,7 +70,7 @@ trait TestCaseTestTrait {
 	 *
 	 * @return void
 	 */
-	public function testAvailabilityExpectPHPExceptionTrait() {
+	final public function testAvailabilityExpectPHPExceptionTrait() {
 		$this->expectDeprecation();
 
 		\trigger_error( 'foo', \E_USER_DEPRECATED );
@@ -83,7 +83,7 @@ trait TestCaseTestTrait {
 	 *
 	 * @throws Exception For testing purposes.
 	 */
-	public function testAvailabilityExpectExceptionMessageMatchesTrait() {
+	final public function testAvailabilityExpectExceptionMessageMatchesTrait() {
 		$this->expectException( Exception::class );
 		$this->expectExceptionMessageMatches( '`^a poly[a-z]+ [a-zA-Z0-9_]+ me(s){2}age$`i' );
 
@@ -95,7 +95,7 @@ trait TestCaseTestTrait {
 	 *
 	 * @return void
 	 */
-	public function testAvailabilityAssertFileEqualsSpecializationsTrait() {
+	final public function testAvailabilityAssertFileEqualsSpecializationsTrait() {
 		self::assertStringEqualsFileIgnoringCase(
 			\dirname( __DIR__ ) . '/Polyfills' . AssertFileEqualsSpecializationsTest::PATH_TO_EXPECTED,
 			"Testing 123\n"
@@ -107,7 +107,7 @@ trait TestCaseTestTrait {
 	 *
 	 * @return void
 	 */
-	public function testAvailabilityAssertionRenamesTrait() {
+	final public function testAvailabilityAssertionRenamesTrait() {
 		$this->assertMatchesRegularExpression( '/foo/', 'foobar' );
 	}
 
@@ -116,7 +116,7 @@ trait TestCaseTestTrait {
 	 *
 	 * @return void
 	 */
-	public function testAvailabilityAssertClosedResource() {
+	final public function testAvailabilityAssertClosedResource() {
 		$resource = \fopen( __FILE__, 'r' );
 		\fclose( $resource );
 
@@ -128,7 +128,7 @@ trait TestCaseTestTrait {
 	 *
 	 * @return void
 	 */
-	public function testAvailabilityEqualToSpecializations() {
+	final public function testAvailabilityEqualToSpecializations() {
 		self::assertThat( [ 2, 3, 1 ], $this->equalToCanonicalizing( [ 3, 2, 1 ] ) );
 	}
 
@@ -139,7 +139,7 @@ trait TestCaseTestTrait {
 	 *
 	 * @return void
 	 */
-	public function testAvailabilityAssertObjectEquals() {
+	final public function testAvailabilityAssertObjectEquals() {
 		$expected = new ValueObject( 'test' );
 		$actual   = new ValueObject( 'test' );
 		$this->assertObjectEquals( $expected, $actual );


### PR DESCRIPTION
PHPUnit 10.0 makes all assertion and exception methods `final`, so the PHPUnit Polyfills should follow suit.

There is one trait which I've exempted from this: `AssertClosedResource`, as when the methods in that trait (and the empty version of that trait) are made `final`, we'll run into trouble on PHPUnit < 9.x.

---

Note to self: [PHPCSExtra](https://github.com/PHPCSStandards/PHPCSExtra) 1.1.0 is expected to include a sniff which can enforce this. Once that release is available, that sniff should be added to the PHPCS ruleset to safeguard this.