### PR TITLE
Composer: remove `coverage-local` script

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -68,9 +68,6 @@
         ],
         "coverage": [
             "@php ./vendor/phpunit/phpunit/phpunit"
-        ],
-        "coverage-local": [
-            "@php ./vendor/phpunit/phpunit/phpunit --coverage-html ./build/coverage-html"
         ]
     }
 }


### PR DESCRIPTION
This can (should) be sorted out via a local dev `phpunit.xml` overload file, not via a Composer script.