### PR TITLE
PHPUnit 10 | AssertIsList trait: polyfill the Assert::assertIsList() method

### DIFF
--- a/README.md
+++ b/README.md
@@ -406,6 +406,17 @@ These methods were introduced in PHPUnit 10.0.0.
 [`Assert::assertStringEqualsStringIgnoringLineEndings()`]:   https://docs.phpunit.de/en/main/assertions.html#assertstringequalsstringignoringlineendings
 [`Assert::assertStringContainsStringIgnoringLineEndings()`]: https://docs.phpunit.de/en/main/assertions.html#assertstringcontainsstringignoringlineendings
 
+#### PHPUnit < 10.0.0: `Yoast\PHPUnitPolyfills\Polyfills\AssertIsList`
+
+Polyfills the following method:
+|                                 |
+|---------------------------------|
+| [`Assert::assertIsList()`] |
+
+This method was introduced in PHPUnit 10.0.0.
+
+[`Assert::assertIsList()`]: https://docs.phpunit.de/en/main/assertions.html#assertislist
+
 
 ### Helper traits
 

--- a/phpunitpolyfills-autoload.php
+++ b/phpunitpolyfills-autoload.php
@@ -91,6 +91,10 @@ if ( \class_exists( 'Yoast\PHPUnitPolyfills\Autoload', false ) === false ) {
 					self::loadAssertObjectEquals();
 					return true;
 
+				case 'Yoast\PHPUnitPolyfills\Polyfills\AssertIsList':
+					self::loadAssertIsList();
+					return true;
+
 				case 'Yoast\PHPUnitPolyfills\Polyfills\AssertIgnoringLineEndings':
 					self::loadAssertIgnoringLineEndings();
 					return true;
@@ -291,6 +295,23 @@ if ( \class_exists( 'Yoast\PHPUnitPolyfills\Autoload', false ) === false ) {
 
 			// PHPUnit >= 9.4.0.
 			require_once __DIR__ . '/src/Polyfills/AssertObjectEquals_Empty.php';
+		}
+
+		/**
+		 * Load the AssertIsList polyfill or an empty trait with the same name
+		 * if a PHPUnit version is used which already contains this functionality.
+		 *
+		 * @return void
+		 */
+		public static function loadAssertIsList() {
+			if ( \method_exists( Assert::class, 'assertIsList' ) === false ) {
+				// PHPUnit < 10.0.0.
+				require_once __DIR__ . '/src/Polyfills/AssertIsList.php';
+				return;
+			}
+
+			// PHPUnit >= 10.0.0.
+			require_once __DIR__ . '/src/Polyfills/AssertIsList_Empty.php';
 		}
 
 		/**

--- a/src/Polyfills/AssertIsList.php
+++ b/src/Polyfills/AssertIsList.php
@@ -1,0 +1,100 @@
+<?php
+
+namespace Yoast\PHPUnitPolyfills\Polyfills;
+
+use PHPUnit\Framework\Assert;
+
+/**
+ * Polyfill the Assert::assertIsList() method.
+ *
+ * Introduced in PHPUnit 10.0.0.
+ *
+ * @link https://github.com/sebastianbergmann/phpunit/pull/4818
+ */
+trait AssertIsList {
+
+	/**
+	 * Asserts that an array is list.
+	 *
+	 * @param mixed  $array   The value to test.
+	 * @param string $message Optional failure message to display.
+	 *
+	 * @return void
+	 */
+	final public static function assertIsList( $array, $message = '' ) {
+		$msg = self::assertIsListFailureDescription( $array );
+		if ( $message !== '' ) {
+			$msg = $message . \PHP_EOL . $msg;
+		}
+
+		if ( \is_array( $array ) === false ) {
+			if ( \method_exists( Assert::class, 'assertIsArray' ) ) {
+				static::assertIsArray( $array, $msg );
+				return;
+			}
+
+			static::assertInternalType( 'array', $array, $msg );
+			return;
+		}
+
+		if ( $array === [] ) {
+			static::assertSame( $array, $array, $msg );
+			return;
+		}
+
+		if ( \function_exists( 'array_is_list' ) ) {
+			// phpcs:ignore PHPCompatibility.FunctionUse.NewFunctions.array_is_listFound -- PHP 8.1+.
+			static::assertTrue( \array_is_list( $array ), $msg );
+			return;
+		}
+
+		$expected = \range( 0, ( \count( $array ) - 1 ) );
+
+		static::assertSame( $expected, \array_keys( $array ), $msg );
+	}
+
+	/**
+	 * Returns the description of the failure.
+	 *
+	 * @param mixed $other The value under test.
+	 *
+	 * @return string
+	 */
+	private static function assertIsListFailureDescription( $other ) {
+		$type = \strtolower( \gettype( $other ) );
+
+		switch ( $type ) {
+			case 'double':
+				$description = 'a float';
+				break;
+
+			case 'resource (closed)':
+				$description = 'a closed resource';
+				break;
+
+			case 'array':
+			case 'integer':
+			case 'object':
+				$description = 'an ' . $type;
+				break;
+
+			case 'boolean':
+			case 'closed resource':
+			case 'float':
+			case 'resource':
+			case 'string':
+				$description = 'a ' . $type;
+				break;
+
+			case 'null':
+				$description = 'null';
+				break;
+
+			default:
+				$description = 'a value of ' . $type;
+				break;
+		}
+
+		return \sprintf( 'Failed asserting that %s is a list.', $description );
+	}
+}

--- a/src/Polyfills/AssertIsList_Empty.php
+++ b/src/Polyfills/AssertIsList_Empty.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Yoast\PHPUnitPolyfills\Polyfills;
+
+/**
+ * Empty trait for use with PHPUnit >= 10.0.0 in which this polyfill is not needed.
+ */
+trait AssertIsList {}

--- a/src/TestCases/TestCasePHPUnitGte8.php
+++ b/src/TestCases/TestCasePHPUnitGte8.php
@@ -8,6 +8,7 @@ use Yoast\PHPUnitPolyfills\Polyfills\AssertClosedResource;
 use Yoast\PHPUnitPolyfills\Polyfills\AssertFileEqualsSpecializations;
 use Yoast\PHPUnitPolyfills\Polyfills\AssertIgnoringLineEndings;
 use Yoast\PHPUnitPolyfills\Polyfills\AssertionRenames;
+use Yoast\PHPUnitPolyfills\Polyfills\AssertIsList;
 use Yoast\PHPUnitPolyfills\Polyfills\AssertObjectEquals;
 use Yoast\PHPUnitPolyfills\Polyfills\EqualToSpecializations;
 use Yoast\PHPUnitPolyfills\Polyfills\ExpectExceptionMessageMatches;
@@ -28,6 +29,7 @@ abstract class TestCase extends PHPUnit_TestCase {
 	use AssertFileEqualsSpecializations;
 	use AssertIgnoringLineEndings;
 	use AssertionRenames;
+	use AssertIsList;
 	use AssertObjectEquals;
 	use EqualToSpecializations;
 	use ExpectExceptionMessageMatches;

--- a/src/TestCases/TestCasePHPUnitLte7.php
+++ b/src/TestCases/TestCasePHPUnitLte7.php
@@ -9,6 +9,7 @@ use Yoast\PHPUnitPolyfills\Polyfills\AssertEqualsSpecializations;
 use Yoast\PHPUnitPolyfills\Polyfills\AssertFileEqualsSpecializations;
 use Yoast\PHPUnitPolyfills\Polyfills\AssertIgnoringLineEndings;
 use Yoast\PHPUnitPolyfills\Polyfills\AssertionRenames;
+use Yoast\PHPUnitPolyfills\Polyfills\AssertIsList;
 use Yoast\PHPUnitPolyfills\Polyfills\AssertIsType;
 use Yoast\PHPUnitPolyfills\Polyfills\AssertObjectEquals;
 use Yoast\PHPUnitPolyfills\Polyfills\AssertStringContains;
@@ -33,6 +34,7 @@ abstract class TestCase extends PHPUnit_TestCase {
 	use AssertFileEqualsSpecializations;
 	use AssertIgnoringLineEndings;
 	use AssertionRenames;
+	use AssertIsList;
 	use AssertIsType;
 	use AssertObjectEquals;
 	use AssertStringContains;

--- a/src/TestCases/XTestCase.php
+++ b/src/TestCases/XTestCase.php
@@ -9,6 +9,7 @@ use Yoast\PHPUnitPolyfills\Polyfills\AssertEqualsSpecializations;
 use Yoast\PHPUnitPolyfills\Polyfills\AssertFileEqualsSpecializations;
 use Yoast\PHPUnitPolyfills\Polyfills\AssertIgnoringLineEndings;
 use Yoast\PHPUnitPolyfills\Polyfills\AssertionRenames;
+use Yoast\PHPUnitPolyfills\Polyfills\AssertIsList;
 use Yoast\PHPUnitPolyfills\Polyfills\AssertIsType;
 use Yoast\PHPUnitPolyfills\Polyfills\AssertObjectEquals;
 use Yoast\PHPUnitPolyfills\Polyfills\AssertStringContains;
@@ -35,6 +36,7 @@ abstract class XTestCase extends PHPUnit_TestCase {
 	use AssertFileEqualsSpecializations;
 	use AssertIgnoringLineEndings;
 	use AssertionRenames;
+	use AssertIsList;
 	use AssertIsType;
 	use AssertObjectEquals;
 	use AssertStringContains;

--- a/tests/Polyfills/AssertIsListTest.php
+++ b/tests/Polyfills/AssertIsListTest.php
@@ -1,0 +1,213 @@
+<?php
+
+namespace Yoast\PHPUnitPolyfills\Tests\Polyfills;
+
+use PHPUnit\Framework\AssertionFailedError;
+use PHPUnit\Framework\TestCase;
+use PHPUnit_Framework_AssertionFailedError;
+use stdClass;
+use Yoast\PHPUnitPolyfills\Polyfills\AssertIsList;
+use Yoast\PHPUnitPolyfills\Polyfills\ExpectExceptionMessageMatches;
+
+/**
+ * Availability test for the functions polyfilled by the AssertIsList trait.
+ *
+ * @covers \Yoast\PHPUnitPolyfills\Polyfills\AssertIsList
+ */
+class AssertIsListTest extends TestCase {
+
+	use AssertIsList;
+	use ExpectExceptionMessageMatches;
+
+	/**
+	 * Verify that the assertIsList() method throws an error when the $array parameter is not an array.
+	 *
+	 * @dataProvider dataAssertIsListFailsOnInvalidInputType
+	 *
+	 * @param mixed  $actual The value to test.
+	 * @param string $type   The type expected in the failure message.
+	 *
+	 * @return void
+	 */
+	public function testAssertIsListFailsOnInvalidInputType( $actual, $type ) {
+		$this->expectException( $this->getAssertionFailedExceptionName() );
+		$this->expectExceptionMessageMatches( '`^Failed asserting that ' . $type . ' is a list`' );
+
+		$this->assertIsList( $actual );
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @return array
+	 */
+	public static function dataAssertIsListFailsOnInvalidInputType() {
+		// Only testing closed resource to not leak an open resource.
+		$resource = \fopen( __DIR__ . '/Fixtures/test.txt', 'r' );
+		\fclose( $resource );
+
+		return [
+			'null' => [
+				'actual' => null,
+				'type'   => 'null',
+			],
+			'boolean' => [
+				'actual' => true,
+				'type'   => 'a boolean',
+			],
+			'integer' => [
+				'actual' => 10,
+				'type'   => 'an integer',
+			],
+			'float' => [
+				'actual' => 5.34,
+				'type'   => 'a float',
+			],
+			'string' => [
+				'actual' => 'text',
+				'type'   => 'a string',
+			],
+			'object' => [
+				'actual' => new stdClass(),
+				'type'   => 'an object',
+			],
+			'closed resource' => [
+				'actual' => $resource,
+				'type'   => ( \PHP_VERSION_ID > 70200 ) ? 'a closed resource' : 'a value of unknown type',
+			],
+		];
+	}
+
+	/**
+	 * Verify availability and functionality of the assertIsList() method.
+	 *
+	 * @dataProvider dataAssertIsListPass
+	 *
+	 * @param array $actual The value to test.
+	 *
+	 * @return void
+	 */
+	public function testAssertIsListPass( $actual ) {
+		$this->assertIsList( $actual );
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @return array
+	 */
+	public static function dataAssertIsListPass() {
+		return [
+			'empty array'                            => [ [] ],
+			'array without keys (integer values)'    => [ [ 0, 1, 2 ] ],
+			'array without keys (mixed values)'      => [ [ 'string', 1.5, new stdClass(), [], null ] ],
+			'array with consecutive numeric keys (ascending)' => [
+				[
+					0 => 0,
+					1 => 1,
+					2 => 2,
+				],
+			],
+			'array with partial keys, starting at 0' => [
+				[
+					0 => 'apple',
+					'orange',
+				],
+			],
+		];
+	}
+
+	/**
+	 * Verify that the assertIsList() method throws an error when the passed $array is not a list.
+	 *
+	 * @dataProvider dataAssertIsListFail
+	 *
+	 * @param array $actual The value to test.
+	 *
+	 * @return void
+	 */
+	public function testAssertIsListFail( $actual ) {
+		$this->expectException( $this->getAssertionFailedExceptionName() );
+		$this->expectExceptionMessage( 'Failed asserting that an array is a list' );
+
+		static::assertIsList( $actual );
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @return array
+	 */
+	public static function dataAssertIsListFail() {
+		return [
+			'array with non-consecutive numeric keys' => [
+				[
+					0 => 0,
+					2 => 2,
+					3 => 3,
+				],
+			],
+			'array with consecutive numeric keys not starting at 0' => [
+				[
+					3 => 0,
+					4 => 1,
+					5 => 2,
+				],
+			],
+			'array with consecutive numeric keys (descending)' => [
+				[
+					0  => 0,
+					-1 => 1,
+					-2 => 2,
+				],
+			],
+			'array with string keys' => [
+				[
+					'a' => 0,
+					'b' => 1,
+				],
+			],
+			'array with partial string keys' => [
+				[
+					'a' => 'apple',
+					'orange',
+				],
+			],
+		];
+	}
+
+	/**
+	 * Verify that the assertIsList() method fails a test with a custom failure message,
+	 * when the custom $message parameter has been passed.
+	 *
+	 * @return void
+	 */
+	public function testAssertIsListFailsWithCustomMessage() {
+		$pattern = '`^This assertion failed for reason XYZ\s+Failed asserting that an array is a list\.`';
+
+		$this->expectException( $this->getAssertionFailedExceptionName() );
+		$this->expectExceptionMessageMatches( $pattern );
+
+		$array = [
+			0 => 0,
+			2 => 2,
+		];
+
+		$this->assertIsList( $array, 'This assertion failed for reason XYZ' );
+	}
+
+	/**
+	 * Helper function: retrieve the name of the "assertion failed" exception to expect (PHPUnit cross-version).
+	 *
+	 * @return string
+	 */
+	public function getAssertionFailedExceptionName() {
+		$exception = AssertionFailedError::class;
+		if ( \class_exists( PHPUnit_Framework_AssertionFailedError::class ) ) {
+			// PHPUnit < 6.
+			$exception = PHPUnit_Framework_AssertionFailedError::class;
+		}
+
+		return $exception;
+	}
+}

--- a/tests/TestCases/TestCaseTestTrait.php
+++ b/tests/TestCases/TestCaseTestTrait.php
@@ -142,4 +142,13 @@ trait TestCaseTestTrait {
 	final public function testAvailabilityAssertIgnoringLineEndings() {
 		self::assertStringContainsStringIgnoringLineEndings( "b\nc", "a\r\nb\r\nc\r\nd" );
 	}
+
+	/**
+	 * Verify availability of trait polyfilled PHPUnit methods [16].
+	 *
+	 * @return void
+	 */
+	final public function testAvailabilityAssertIsList() {
+		static::assertIsList( [ 0, 1, 2 ] );
+	}
 }


### PR DESCRIPTION
PHPUnit 10.0.0 introduces the new `Assert::assertIsList()` method.

This commit:
* Adds two traits with the same name. One to polyfill the methods when not available in PHPUnit. The other - an empty trait - to allow for `use`-ing the trait in PHPUnit versions in which the methods are already natively available.
* Logic to the custom autoloader which will load the correct trait depending on the PHPUnit version used.
* Functional tests for the functionality polyfilled.

Note: the methods use `static::` to call the PHPUnit native functionality. This allows for existing method overloads in a child class of the PHPUnit native `TestCase` to be respected.

Includes:
* Adding the new polyfill to the existing `TestCases` classes and adding a test for the polyfill availability to the `TestCaseTestTrait`.

Refs:
* https://github.com/sebastianbergmann/phpunit/pull/4818
* https://github.com/sebastianbergmann/phpunit/commit/71f507496aa1a483b32d9257d6f3477e6e5c091d
* https://github.com/sebastianbergmann/phpunit/commit/e04a947baf8d9b800ac8a1223f3be0f090cacf3e
* https://github.com/sebastianbergmann/phpunit/commit/2bc1aea7dabc200681a8b6c7eb399d60bd03379f