### PR TITLE
Tests: add separate configuration file for PHPUnit 10

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -14,6 +14,7 @@
 /.remarkignore export-ignore
 /.remarkrc export-ignore
 /phpunit.xml.dist export-ignore
+/phpunit10.xml.dist export-ignore
 /tests/ export-ignore
 
 #

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -108,11 +108,18 @@ jobs:
           # Bust the cache at least once a month - output format: YYYY-MM.
           custom-cache-suffix: $(date -u "+%Y-%m")
 
-      - name: Run the unit tests
-        if: ${{ matrix.phpunit != '^10.0' }}
+      - name: Grab PHPUnit version
+        id: phpunit_version
+        run: echo "VERSION=$(vendor/bin/phpunit --version | grep --only-matching --max-count=1 --extended-regexp '\b[0-9]+\.[0-9]+')" >> $GITHUB_OUTPUT
+
+      - name: "DEBUG: Show grabbed version"
+        run: echo ${{ steps.phpunit_version.outputs.VERSION }}
+
+      - name: "Run the unit tests (PHPUnit < 10)"
+        if: ${{ ! startsWith( steps.phpunit_version.outputs.VERSION, '10.' ) }}
         run: composer test
 
-      - name: Trial run the unit tests against PHPUnit 10.0
-        if: ${{ matrix.phpunit == '^10.0' }}
+      - name: "Trial run the unit tests against PHPUnit 10.0"
+        if: ${{ startsWith( steps.phpunit_version.outputs.VERSION, '10.' ) }}
         continue-on-error: true
-        run: composer test
+        run: composer test10

--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,6 @@ vendor/
 /phpcs.xml
 .cache/phpcs.cache
 /phpunit.xml
+/phpunit10.xml
 /.phpunit.result.cache
 /build/

--- a/composer.json
+++ b/composer.json
@@ -68,6 +68,12 @@
         ],
         "coverage": [
             "@php ./vendor/phpunit/phpunit/phpunit"
+        ],
+        "test10": [
+            "@php ./vendor/phpunit/phpunit/phpunit -c phpunit10.xml.dist --no-coverage"
+        ],
+        "coverage10": [
+            "@php ./vendor/phpunit/phpunit/phpunit -c phpunit10.xml.dist"
         ]
     }
 }

--- a/phpunit10.xml.dist
+++ b/phpunit10.xml.dist
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.0/phpunit.xsd"
+    backupGlobals="true"
+    bootstrap="./tests/bootstrap.php"
+    beStrictAboutOutputDuringTests="true"
+    beStrictAboutTestsThatDoNotTestAnything="true"
+    colors="true"
+    cacheDirectory=".cache/phpcs.cache"
+    requireCoverageMetadata="true"
+    displayDetailsOnTestsThatTriggerErrors="true"
+    displayDetailsOnTestsThatTriggerWarnings="true"
+    displayDetailsOnTestsThatTriggerNotices="true"
+    displayDetailsOnTestsThatTriggerDeprecations="true"
+    >
+
+    <testsuites>
+        <testsuite name="PHPUnitPolyfills">
+            <directory suffix="Test.php">./tests/</directory>
+        </testsuite>
+    </testsuites>
+
+    <coverage includeUncoveredFiles="true">
+        <include>
+            <directory suffix=".php">./src/</directory>
+        </include>
+        <exclude>
+            <file>src/Polyfills/AssertClosedResource_Empty.php</file>
+        </exclude>
+        <report>
+            <clover outputFile="build/logs/clover.xml"/>
+        </report>
+    </coverage>
+
+</phpunit>


### PR DESCRIPTION
The configuration file specification has undergone changes in PHPUnit 9.3 and 10.0.

Most notably:
* In PHPUnit 9.3, the manner of specifying the code coverage configuration has changed.
* In PHPUnit 10.0, a significant number of attributes of the `<phpunit>` element were removed or renamed.

While the `--migrate-configuration` command can upgrade a configuration for the changes in the format made in PHPUnit 9.3, some of the changes in the configuration format in PHPUnit 10 don't have one-on-one replacements and/or are not taken into account.

With that in mind, I deem it more appropriate to have a dedicated PHPUnit configuration file for PHPUnit 10 to ensure the test run will behave as intended.

This commit adds this dedicated configuration file for PHPUnit 10+.

Includes:
* Ignoring the new file for package archives.
* Allowing for a local override file.
* Adding scripts to the `composer.json` file to run the tests using this new configuration file.
* Updating the GH Actions `test` workflow to trigger the tests on PHPUnit 10 with this configuration file.

Take note that the `cacheDirectory` option has been set to the same value as PHPUnit natively already used in PHPUnit 8 and 9, even though this is a different value as is used by default in PHPUnit 10.

Ref:
* https://github.com/sebastianbergmann/phpunit/blob/main/ChangeLog-10.0.md#1000---2023-02-03