### PR TITLE
Modernize: use constant scalar expressions

### DIFF
--- a/tests/Polyfills/AssertFileEqualsSpecializationsTest.php
+++ b/tests/Polyfills/AssertFileEqualsSpecializationsTest.php
@@ -14,15 +14,15 @@ final class AssertFileEqualsSpecializationsTest extends TestCase {
 
 	use AssertFileEqualsSpecializations;
 
-	const PATH_TO_EXPECTED = '/Fixtures/AssertFileEqualsSpecialization_Expected.txt';
+	const PATH_TO_EXPECTED = __DIR__ . '/Fixtures/AssertFileEqualsSpecialization_Expected.txt';
 
-	const PATH_TO_EQUALS = '/Fixtures/AssertFileEqualsSpecialization_Equals.txt';
+	const PATH_TO_EQUALS = __DIR__ . '/Fixtures/AssertFileEqualsSpecialization_Equals.txt';
 
-	const PATH_TO_NOT_EQUALS = '/Fixtures/AssertFileEqualsSpecialization_NotEquals.txt';
+	const PATH_TO_NOT_EQUALS = __DIR__ . '/Fixtures/AssertFileEqualsSpecialization_NotEquals.txt';
 
-	const PATH_TO_EQUALS_CI = '/Fixtures/AssertFileEqualsSpecialization_EqualsCI.txt';
+	const PATH_TO_EQUALS_CI = __DIR__ . '/Fixtures/AssertFileEqualsSpecialization_EqualsCI.txt';
 
-	const PATH_TO_NOT_EQUALS_CI = '/Fixtures/AssertFileEqualsSpecialization_NotEqualsCI.txt';
+	const PATH_TO_NOT_EQUALS_CI = __DIR__ . '/Fixtures/AssertFileEqualsSpecialization_NotEqualsCI.txt';
 
 	/**
 	 * Verify availability of the assertFileEqualsCanonicalizing() method.
@@ -30,9 +30,7 @@ final class AssertFileEqualsSpecializationsTest extends TestCase {
 	 * @return void
 	 */
 	public function testAssertFileEqualsCanonicalizing() {
-		$expected = __DIR__ . self::PATH_TO_EXPECTED;
-		$input    = __DIR__ . self::PATH_TO_EQUALS;
-		$this->assertFileEqualsCanonicalizing( $expected, $input );
+		$this->assertFileEqualsCanonicalizing( self::PATH_TO_EXPECTED, self::PATH_TO_EQUALS );
 	}
 
 	/**
@@ -41,9 +39,7 @@ final class AssertFileEqualsSpecializationsTest extends TestCase {
 	 * @return void
 	 */
 	public function testAssertFileEqualsIgnoringCase() {
-		$expected = __DIR__ . self::PATH_TO_EXPECTED;
-		$input    = __DIR__ . self::PATH_TO_EQUALS_CI;
-		self::assertFileEqualsIgnoringCase( $expected, $input );
+		self::assertFileEqualsIgnoringCase( self::PATH_TO_EXPECTED, self::PATH_TO_EQUALS_CI );
 	}
 
 	/**
@@ -52,9 +48,7 @@ final class AssertFileEqualsSpecializationsTest extends TestCase {
 	 * @return void
 	 */
 	public function testAssertFileNotEqualsCanonicalizing() {
-		$expected = __DIR__ . self::PATH_TO_EXPECTED;
-		$input    = __DIR__ . self::PATH_TO_NOT_EQUALS;
-		static::assertFileNotEqualsCanonicalizing( $expected, $input );
+		static::assertFileNotEqualsCanonicalizing( self::PATH_TO_EXPECTED, self::PATH_TO_NOT_EQUALS );
 	}
 
 	/**
@@ -63,9 +57,7 @@ final class AssertFileEqualsSpecializationsTest extends TestCase {
 	 * @return void
 	 */
 	public function testAssertFileNotEqualsIgnoringCase() {
-		$expected = __DIR__ . self::PATH_TO_EXPECTED;
-		$input    = __DIR__ . self::PATH_TO_NOT_EQUALS_CI;
-		$this->assertFileNotEqualsIgnoringCase( $expected, $input );
+		$this->assertFileNotEqualsIgnoringCase( self::PATH_TO_EXPECTED, self::PATH_TO_NOT_EQUALS_CI );
 	}
 
 	/**
@@ -74,7 +66,7 @@ final class AssertFileEqualsSpecializationsTest extends TestCase {
 	 * @return void
 	 */
 	public function testAssertStringEqualsFileCanonicalizing() {
-		static::assertStringEqualsFileCanonicalizing( __DIR__ . self::PATH_TO_EXPECTED, "testing 123\n" );
+		static::assertStringEqualsFileCanonicalizing( self::PATH_TO_EXPECTED, "testing 123\n" );
 	}
 
 	/**
@@ -83,7 +75,7 @@ final class AssertFileEqualsSpecializationsTest extends TestCase {
 	 * @return void
 	 */
 	public function testAssertStringEqualsFileIgnoringCase() {
-		self::assertStringEqualsFileIgnoringCase( __DIR__ . self::PATH_TO_EXPECTED, "Testing 123\n" );
+		self::assertStringEqualsFileIgnoringCase( self::PATH_TO_EXPECTED, "Testing 123\n" );
 	}
 
 	/**
@@ -92,7 +84,7 @@ final class AssertFileEqualsSpecializationsTest extends TestCase {
 	 * @return void
 	 */
 	public function testAssertStringNotEqualsFileCanonicalizing() {
-		$this->assertStringNotEqualsFileCanonicalizing( __DIR__ . self::PATH_TO_EXPECTED, "test 123\n" );
+		$this->assertStringNotEqualsFileCanonicalizing( self::PATH_TO_EXPECTED, "test 123\n" );
 	}
 
 	/**
@@ -101,6 +93,6 @@ final class AssertFileEqualsSpecializationsTest extends TestCase {
 	 * @return void
 	 */
 	public function testAssertStringNotEqualsFileIgnoringCase() {
-		$this->assertStringNotEqualsFileIgnoringCase( __DIR__ . self::PATH_TO_EXPECTED, "Test 123\n" );
+		$this->assertStringNotEqualsFileIgnoringCase( self::PATH_TO_EXPECTED, "Test 123\n" );
 	}
 }

--- a/tests/Polyfills/AssertionRenamesTest.php
+++ b/tests/Polyfills/AssertionRenamesTest.php
@@ -16,14 +16,17 @@ final class AssertionRenamesTest extends TestCase {
 	use AssertionRenames;
 	use AssertIsType;
 
+	const NOT_EXISTENT_FILE = __DIR__ . \DIRECTORY_SEPARATOR . 'NotExisting.php';
+
+	const NOT_EXISTENT_DIR = __DIR__ . \DIRECTORY_SEPARATOR . 'NotExisting' . \DIRECTORY_SEPARATOR;
+
 	/**
 	 * Verify availability of the assertIsNotReadable() method.
 	 *
 	 * @return void
 	 */
 	public function testAssertIsNotReadable() {
-		$path = __DIR__ . \DIRECTORY_SEPARATOR . 'NotExisting.php';
-		$this->assertIsNotReadable( $path );
+		$this->assertIsNotReadable( self::NOT_EXISTENT_FILE );
 	}
 
 	/**
@@ -32,8 +35,7 @@ final class AssertionRenamesTest extends TestCase {
 	 * @return void
 	 */
 	public function testAssertIsNotWritable() {
-		$path = __DIR__ . \DIRECTORY_SEPARATOR . 'NotExisting' . \DIRECTORY_SEPARATOR;
-		self::assertIsNotWritable( $path );
+		self::assertIsNotWritable( self::NOT_EXISTENT_DIR );
 	}
 
 	/**
@@ -42,8 +44,7 @@ final class AssertionRenamesTest extends TestCase {
 	 * @return void
 	 */
 	public function testAssertDirectoryDoesNotExist() {
-		$path = __DIR__ . \DIRECTORY_SEPARATOR . 'NotExisting' . \DIRECTORY_SEPARATOR;
-		static::assertDirectoryDoesNotExist( $path );
+		static::assertDirectoryDoesNotExist( self::NOT_EXISTENT_DIR );
 	}
 
 	/**
@@ -98,8 +99,7 @@ final class AssertionRenamesTest extends TestCase {
 	 * @return void
 	 */
 	public function testAssertFileDoesNotExist() {
-		$path = __DIR__ . \DIRECTORY_SEPARATOR . 'NotExisting.php';
-		static::assertFileDoesNotExist( $path );
+		static::assertFileDoesNotExist( self::NOT_EXISTENT_FILE );
 	}
 
 	/**

--- a/tests/TestCases/TestCaseTestTrait.php
+++ b/tests/TestCases/TestCaseTestTrait.php
@@ -86,7 +86,7 @@ trait TestCaseTestTrait {
 	 */
 	final public function testAvailabilityAssertFileEqualsSpecializationsTrait() {
 		self::assertStringEqualsFileIgnoringCase(
-			\dirname( __DIR__ ) . '/Polyfills' . AssertFileEqualsSpecializationsTest::PATH_TO_EXPECTED,
+			AssertFileEqualsSpecializationsTest::PATH_TO_EXPECTED,
 			"Testing 123\n"
 		);
 	}


### PR DESCRIPTION
... where appropriate.

This largely reverts commit 83ba7e30c0f479810a66d053db99b702e33f75ea.