### PR TITLE
RemarkLint: switch plugin + fix broken link

### DIFF
--- a/.github/workflows/markdown.yml
+++ b/.github/workflows/markdown.yml
@@ -84,6 +84,7 @@ jobs:
           remark-preset-lint-markdown-style-guide
           remark-lint-checkbox-content-indent
           remark-lint-linebreak-style
+          remark-lint-no-dead-urls
           remark-lint-no-empty-url
           remark-lint-no-heading-like-paragraph
           remark-lint-no-reference-like-url
@@ -94,7 +95,6 @@ jobs:
           remark-lint-list-item-punctuation
           remark-lint-match-punctuation
           remark-lint-no-hr-after-heading
-          remark-lint-are-links-valid-alive
           remark-lint-are-links-valid-duplicate
           remark-validate-links
 

--- a/.remarkrc
+++ b/.remarkrc
@@ -8,6 +8,7 @@
     ["remark-lint-linebreak-style", "unix"],
     ["remark-lint-link-title-style", "\""],
     ["remark-lint-ordered-list-marker-style", "."],
+    "remark-lint-no-dead-urls",
     "remark-lint-no-duplicate-definitions",
     "remark-lint-no-empty-url",
     "remark-lint-no-file-name-consecutive-dashes",
@@ -28,7 +29,6 @@
     "remark-lint-list-item-punctuation",
     "remark-lint-match-punctuation",
     "remark-lint-no-hr-after-heading",
-    "remark-lint-are-links-valid-alive",
     "remark-lint-are-links-valid-duplicate",
     "remark-validate-links"
   ]

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ This means that features which PHPUnit no longer supports in PHPUnit 10.x, like 
 Please refer to the [PHPUnit 10 release notification] and [PHPUnit 10 changelog] to inform your decision on whether or not to upgrade (yet).
 
 [PHPUnit 10 release notification]: https://phpunit.de/announcements/phpunit-10.html
-[PHPUnit 10 changelog]:            https://github.com/sebastianbergmann/phpunit/blob/main/ChangeLog-10.0.md
+[PHPUnit 10 changelog]:            https://github.com/sebastianbergmann/phpunit/blob/10.0.19/ChangeLog-10.0.md
 
 
 Using this library


### PR DESCRIPTION
### RemarkLint: switch plugin

The [`remark-lint-are-links-valid-alive`](https://github.com/wemake-services/remark-lint-are-links-valid) plugin has been abandoned and doesn't allow to skip false positives.
The [`remark-lint-no-dead-urls`](https://github.com/remarkjs/remark-lint-no-dead-urls) plugin is still maintained and does allow adding some configuration to skip false positives.

This commit switches the one plugin out for the other.

### README: fix link to PHPUnit 10 changelog 