### PR TITLE
CI/QA: start recording code coverage

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,6 +22,7 @@ jobs:
       matrix:
         php: ['5.4', '5.5', '5.6', '7.0', '7.1', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2']
         phpunit: ['auto']
+        coverage: [true]
         experimental: [false]
 
         include:
@@ -33,45 +34,59 @@ jobs:
           # would always be installed as "low", which would break the builds for PHP 7.2+.
           - php: '5.6'
             phpunit: '5.7.21'
+            coverage: true
             experimental: false
           - php: '7.0'
             phpunit: '5.7.27'
+            coverage: true
             experimental: false
           - php: '7.1'
             phpunit: '5.7.21'
+            coverage: true
             experimental: false
           - php: '7.2'
             phpunit: '6.3.1'
+            coverage: true
             experimental: false
           - php: '7.3'
             phpunit: '7.2.7'
+            coverage: true
             experimental: false
           - php: '7.4'
             phpunit: '8.1.6'
+            coverage: true
             experimental: false
           - php: '8.0'
             phpunit: '8.5.16'
+            # PHPUnit 8.x does not support code coverage on PHP 8.x.
+            coverage: false
             experimental: false
           - php: '8.0'
             phpunit: '9.3.0'
+            coverage: true
             experimental: false
           - php: '8.1'
             phpunit: '9.3.0'
+            coverage: true
             experimental: false
           - php: '8.2'
             phpunit: '9.3.0'
+            coverage: true
             experimental: false
 
           # Experimental builds.
           - php: '8.3'
             phpunit: 'auto' # PHPUnit 9.x.
+            coverage: false
             experimental: true
 
           - php: '8.1'
             phpunit: '^10.0'
+            coverage: false
             experimental: true
           - php: '8.2'
             phpunit: '^10.0'
+            coverage: false
             experimental: true
 
     name: "Tests: PHP ${{ matrix.php }} - PHPUnit: ${{matrix.phpunit}}"
@@ -87,7 +102,7 @@ jobs:
         with:
           php-version: ${{ matrix.php }}
           ini-values: zend.assertions=1, error_reporting=-1, display_errors=On
-          coverage: none
+          coverage: ${{ matrix.coverage == true && 'xdebug' || 'none' }}
 
       - name: 'Composer: set PHPUnit version for tests'
         if: ${{ matrix.phpunit != 'auto' }}
@@ -111,10 +126,46 @@ jobs:
           custom-cache-suffix: $(date -u "+%Y-%m")
 
       - name: Run the unit tests
-        if: ${{ matrix.phpunit != '^10.0' }}
+        if: ${{ matrix.coverage == false && matrix.phpunit != '^10.0' }}
         run: composer test
+
+      - name: Run the unit tests with code coverage
+        if: ${{ matrix.coverage == true && matrix.phpunit != '^10.0' }}
+        run: composer coverage
 
       - name: Trial run the unit tests against PHPUnit 10.0
         if: ${{ matrix.phpunit == '^10.0' }}
         continue-on-error: true
         run: composer test
+
+      # Uploading the results with PHP Coveralls v1 won't work from GH Actions, so switch the PHP version.
+      - name: Switch to PHP 7.4
+        if: ${{ success() && matrix.coverage == true && ( matrix.php == '5.4' || startsWith( matrix.php, '8' ) ) }}
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: 7.4
+          coverage: none
+
+      # Global install is used to prevent a conflict with the local composer.lock in PHP 8.0+.
+      - name: Install Coveralls
+        if: ${{ success() && matrix.coverage == true }}
+        run: composer global require php-coveralls/php-coveralls:"^2.5.3" --no-interaction
+
+      - name: Upload coverage results to Coveralls
+        if: ${{ success() && matrix.coverage == true }}
+        env:
+          COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_TOKEN }}
+          COVERALLS_PARALLEL: true
+          COVERALLS_FLAG_NAME: php-${{ matrix.php }}-phpunit-${{ matrix.phpunit }}
+        run: php-coveralls -v -x build/logs/clover.xml
+
+  coveralls-finish:
+    needs: test
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Coveralls Finished
+        uses: coverallsapp/github-action@v2
+        with:
+          github-token: ${{ secrets.COVERALLS_TOKEN }}
+          parallel-finished: true

--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ PHPUnit Polyfills
 [![CS Build Status](https://github.com/Yoast/PHPUnit-Polyfills/actions/workflows/cs.yml/badge.svg)](https://github.com/Yoast/PHPUnit-Polyfills/actions/workflows/cs.yml)
 [![Lint Build Status](https://github.com/Yoast/PHPUnit-Polyfills/actions/workflows/lint.yml/badge.svg)](https://github.com/Yoast/PHPUnit-Polyfills/actions/workflows/lint.yml)
 [![Test Build Status](https://github.com/Yoast/PHPUnit-Polyfills/actions/workflows/test.yml/badge.svg)](https://github.com/Yoast/PHPUnit-Polyfills/actions/workflows/test.yml)
+[![Coverage Status](https://coveralls.io/repos/github/Yoast/PHPUnit-Polyfills/badge.svg?branch=1.x)](https://coveralls.io/github/Yoast/PHPUnit-Polyfills?branch=1.x)
+
 [![Minimum PHP Version](https://img.shields.io/packagist/php-v/yoast/phpunit-polyfills.svg?maxAge=3600)](https://packagist.org/packages/yoast/phpunit-polyfills)
 [![License: BSD3](https://poser.pugx.org/yoast/phpunit-polyfills/license)](https://github.com/Yoast/PHPUnit-Polyfills/blob/main/LICENSE)
 

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -25,6 +25,7 @@
     </filter>
 
     <logging>
+        <log type="coverage-text" target="php://stdout" showOnlySummary="true"/>
         <log type="coverage-clover" target="build/logs/clover.xml"/>
     </logging>
 


### PR DESCRIPTION
This commit make the necessary changes to start recording and uploading code coverage data to Coveralls.

Includes:
* Updating the GH Actions `test` worflow to run (nearly) all non-experimental builds with code coverage and upload the results.
    There is one exception: PHPUnit 8.x is not compatible with PHP 8.0+ for recording code coverage, so the PHP `8.0` with PHPUnit `8.x` build is exempt.
* Updating the PHPUnit config to show an inline code coverage summary.
* Adding a code coverage badge to the README.

Not included as already in place:
* Ignoring the potentially generated code coverage files in the `build/*` directory to prevent it being committed.
* Adding a script to the `composer.json` file to run code coverage.

Notes:
* Coverage will be recorded using `Xdebug` as the code coverage driver.
* The `php-coveralls/php-coveralls` package is used to convert the coverage information from a format as generated by PHPUnit to a format as can be consumed by Coveralls.
    - As this package is only needed for the upload to Coveralls, the package has **not** been added it to the `composer.json` file, but will be (global) installed in the GH Actions workflow only.
    - The `php-coveralls/php-coveralls` package is not 100% compatible with PHP 8.x (yet), so for uploading the coverage generated using PHP 8.x, we switch to PHP 7.4 for uploading the code coverage reports.
    - For uploading code coverage with PHP < 5.5, `php-coveralls/php-coveralls` `1.x` is needed, but that version of the package doesn't play nice with GH Actions.
        To get round that, the jobs which run on PHP 5.4, will switch to PHP 7.4 for uploading the code coverage reports.
* Coveralls requires a token to identify the repo and prevent unauthorized uploads.
    This token has been added to the repository secrets.
    People with admin access to the GH repo automatically also have access to the admin settings in Coveralls.
    If ever needed, the Coveralls token can be found (and regenerated) in the Coveralls admin for a repo.
    After regeneration, the token as stored in the GH repo Settings -> Secrets and Variables -> Actions -> Repository secrets should be updated.
* As the workflow sends multiple code coverage reports to Coveralls, we need to tell it to process those reports in parallel and give each report a unique name.
    That's what the `COVERALLS_PARALLEL` and `COVERALLS_FLAG_NAME` settings are about.
* The `coveralls-finish` job will signal to Coveralls that all reports have been uploaded.
    This basically gives the "okay" to Coveralls to report on the changes in code coverage via a comment on a GitHub PR as well as via a status check.

The pertinent Coveralls settings used for this repo are:
* "Only send aggregate Coverage updates to SCM": enabled
* "Leave comments": enabled
* "(Comment) Format": compact
* "Use Status API": enabled
* "Coverage threshold for failure": 95%
* "Coverage decrease threshold for failure": 0.5%