### PR TITLE
GH Actions: fix failing remark build

### DIFF
--- a/.remarkrc
+++ b/.remarkrc
@@ -24,7 +24,7 @@
     "remark-lint-no-unneeded-full-reference-link",
     "remark-lint-no-unused-definitions",
     ["remark-lint-strikethrough-marker", "~~"],
-    ["remark-lint-table-cell-padding", "consistent"],
+    "remark-lint-table-pipe-alignment",
     "remark-lint-heading-whitespace",
     "remark-lint-list-item-punctuation",
     "remark-lint-match-punctuation",

--- a/README.md
+++ b/README.md
@@ -701,10 +701,10 @@ For frequently used, removed PHPUnit functionality, "helpers" may be provided. T
 
 #### Removed functionality without PHPUnit native replacement
 
-| PHPUnit | Removed               | Issue     | Remarks                |
-|---------|-----------------------|-----------|------------------------|
+| PHPUnit | Removed               | Issue          | Remarks                                                                                                                                                                                                                                                                                                                                                                                                                                           |
+|---------|-----------------------|----------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | 9.0.0   | `assertArraySubset()` | [#1][issue #1] | The [`dms/phpunit-arraysubset-asserts`](https://packagist.org/packages/dms/phpunit-arraysubset-asserts) package polyfills this functionality.<br/>As of [version 0.3.0](https://github.com/rdohms/phpunit-arraysubset-asserts/releases/tag/v0.3.0) this package can be installed in combination with PHP 5.4 - current and PHPUnit 4.8.36/5.7.21 - current.<br/>Alternatively, tests can be refactored using the patterns outlined in [issue #1]. |
-| 9.0.0   | `assertAttribute*()`  | [#2][issue #2] | Refactor the tests to not directly test private/protected properties.<br/>As an interim solution, the [`Yoast\PHPUnitPolyfills\Helpers\AssertAttributeHelper`](#yoastphpunitpolyfillshelpersassertattributehelper) trait is available. |
+| 9.0.0   | `assertAttribute*()`  | [#2][issue #2] | Refactor the tests to not directly test private/protected properties.<br/>As an interim solution, the [`Yoast\PHPUnitPolyfills\Helpers\AssertAttributeHelper`](#yoastphpunitpolyfillshelpersassertattributehelper) trait is available.                                                                                                                                                                                                            |
 
 [issue #1]: https://github.com/Yoast/PHPUnit-Polyfills/issues/1
 [issue #2]: https://github.com/Yoast/PHPUnit-Polyfills/issues/2


### PR DESCRIPTION
### GH Actions: fix failing build

Somewhere in the Remark toolchain something has changed which means that it now throws warnings about the cell padding for aligned tables.

As those aligned tables are by design (for readability during maintenance of the markdown), this commit is set up to removes those warnings and to enforce aligned tables.

Failing build: https://github.com/Yoast/PHPUnit-Polyfills/actions/runs/4977022049/jobs/8905635380

Refs:
* https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-table-pipe-alignment
* https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-table-cell-padding

### README: minor formatting fix

This table wasn't aligned (yet) due to its size. Fixed now.