### PR TITLE
GH Actions: tweaks for the markdown QA check

### DIFF
--- a/.remarkrc
+++ b/.remarkrc
@@ -24,7 +24,7 @@
     "remark-lint-no-unneeded-full-reference-link",
     "remark-lint-no-unused-definitions",
     ["remark-lint-strikethrough-marker", "~~"],
-    "remark-lint-table-pipe-alignment",
+    ["remark-lint-table-cell-padding", "consistent"],
     "remark-lint-heading-whitespace",
     "remark-lint-list-item-punctuation",
     "remark-lint-match-punctuation",


### PR DESCRIPTION
Looks like the `remark-lint` project has released a new version fixing the bug causing the failing build earlier this week.

This commit reverts the rule change from PR #124.

Refs:
* https://github.com/remarkjs/remark-lint/releases/tag/9.1.2
* https://github.com/remarkjs/remark-lint/commit/639271aed95fa579623f385bade4939a9c70e959