### PR TITLE
Changelog and readme updates for the 2.0.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,64 @@ This projects adheres to [Keep a CHANGELOG](http://keepachangelog.com/) and uses
 
 _Nothing yet._
 
+## [2.0.0] - 2023-06-06
+
+### PHPUnit 10 support
+
+This release updates the PHPUnit Polyfills to allow for _"writing your tests for PHPUnit 10 and running them all the way back to PHPUnit 5"_.
+
+Please keep in mind that the PHPUnit Polyfills provide _forward_-compatibility. This means that features which PHPUnit no longer supports in PHPUnit 10.x, like expecting PHP deprecation notices or warnings, are also no longer supported in the 2.0 release of the PHPUnit Polyfills.
+
+Please refer to the [PHPUnit 10 release notification] and [PHPUnit 10 changelog] to inform your decision on whether or not to upgrade (yet).
+
+Projects which don't use any of the new or removed functionality in their test suite, can, of course, use the PHPUnit Polyfills 1.x and 2.x series side-by-side, like so `composer require --dev yoast/phpunit-polyfills:"^1.0 || ^2.0"`.
+
+[PHPUnit 10 release notification]: https://phpunit.de/announcements/phpunit-10.html
+[PHPUnit 10 changelog]:            https://github.com/sebastianbergmann/phpunit/blob/10.0.19/ChangeLog-10.0.md
+
+> :warning: **Important: about the TestListener polyfill** :warning:
+>
+> The TestListener polyfill in PHPUnit Polyfills 2.0 is **[not (yet) compatible with PHPUnit 10.0.0][polyfill-ticket]**.
+>
+> If you need the TestListener polyfill, it is recommended to stay on the PHPUnit Polyfills 1.x series for the time being and to watch the [related ticket][polyfill-ticket].
+
+[polyfill-ticket]: https://github.com/Yoast/PHPUnit-Polyfills/issues/128
+
+
+### Changelog
+
+#### Added
+* `Yoast\PHPUnitPolyfills\Polyfills\AssertIgnoringLineEndings` trait to polyfill the `Assert::assertStringEqualsStringIgnoringLineEndings()` and the `Assert::assertStringContainsStringIgnoringLineEndings()` methods as introduced in PHPUnit 10.0.0. PR [#109].
+* `Yoast\PHPUnitPolyfills\Polyfills\AssertIsList` trait to polyfill the `Assert::assertIsList()` method as introduced in PHPUnit 10.0.0. PR [#110].
+* `Yoast\PHPUnitPolyfills\Polyfills\AssertObjectProperty` trait to polyfill the `Assert::assertObjectHasProperty()` and the `Assert::assertObjectNotHasProperty()` methods as introduced in PHPUnit 10.1.0. PR [#116].
+
+#### Changed
+* Composer: allow for installation of PHPUnit 10.x. PR [#130]
+* Nearly all assertion methods are now `final`. This alignes them with the same change made upstream in PHPUnit 10.0.0. PR [#104].
+* General housekeeping.
+
+#### Removed
+* Support for PHP < 5.6. PR [#102].
+* Support for PHPUnit < 5.7.21. PR [#102].
+* Support for expecting PHP deprecations, notices, warnings and error via the `Yoast\PHPUnitPolyfills\Polyfills\ExpectPHPException` trait. PR [#108].
+    The trait has been removed completely as PHPUnit 10 no longer supports this functionality.
+* The `Yoast\PHPUnitPolyfills\Polyfills\AssertNumericType` trait which is no longer needed now support for PHPUnit < 5.7 has been dropped. PR [#102].
+* The `Yoast\PHPUnitPolyfills\Polyfills\ExpectException` trait which is no longer needed now support for PHPUnit < 5.7 has been dropped. PR [#102].
+* The `Yoast\PHPUnitPolyfills\Polyfills\AssertFileDirectory` trait which is no longer needed now support for PHPUnit < 5.7 has been dropped. PR [#102].
+
+[#102]: https://github.com/Yoast/PHPUnit-Polyfills/pull/102
+[#104]: https://github.com/Yoast/PHPUnit-Polyfills/pull/104
+[#108]: https://github.com/Yoast/PHPUnit-Polyfills/pull/108
+[#109]: https://github.com/Yoast/PHPUnit-Polyfills/pull/109
+[#110]: https://github.com/Yoast/PHPUnit-Polyfills/pull/110
+[#116]: https://github.com/Yoast/PHPUnit-Polyfills/pull/116
+[#130]: https://github.com/Yoast/PHPUnit-Polyfills/pull/130
+
+
 ## [1.0.5] - 2023-03-31
 
 ### Fixed
-* A custom `$message` parameter passed to an assertion, will no longer overrule an emulated "assertion failed" message, but will be prefixed to it instead. PR [#97]
+* A custom `$message` parameter passed to an assertion, will no longer overrule an emulated "assertion failed" message, but will be prefixed to it instead. PR [#97].
     This applies to the following polyfills:
     - `assertIsClosedResource()`
     - `assertIsNotClosedResource()`
@@ -27,9 +81,9 @@ _Nothing yet._
 
 ### Changed
 * The `develop` branch has been removed. Development will now take place in the `1.x` and `2.x` branches.
-* README: links to the PHPUnit manual now point explicitly to the PHPUnit 9.x documentation. PR [#94]
-* README: new sub-section about PHPUnit version support. PR [#99]
-* README: various minor improvements. PRs [#92], [#93]
+* README: links to the PHPUnit manual now point explicitly to the PHPUnit 9.x documentation. PR [#94].
+* README: new sub-section about PHPUnit version support. PR [#99].
+* README: various minor improvements. PRs [#92], [#93].
 * General housekeeping.
 
 [#92]: https://github.com/Yoast/PHPUnit-Polyfills/pull/92
@@ -70,14 +124,14 @@ This is a maintenance release.
 As of version 2.15.0 of the `shivammathur/setup-php` action for GitHub Actions, the PHPUnit Polyfills can be installed directly from this action using the `tools` key.
 
 ### Added
-* README: FAQ section about installing and using the library via the `shivammathur/setup-php` action. PR [#52]
+* README: FAQ section about installing and using the library via the `shivammathur/setup-php` action. PR [#52].
 
 ### Changed
 * README: minor textual clarifications and improvements. PRs [#52], [#54], props [Pierre Gordon].
 * General housekeeping.
 
 ### Fixed
-* Autoloader: improved compatibility with packages which create a `class_alias` for the `PHPUnit_Runner_Version` or `PHPUnit\Runner\Version` class. PR [#59]
+* Autoloader: improved compatibility with packages which create a `class_alias` for the `PHPUnit_Runner_Version` or `PHPUnit\Runner\Version` class. PR [#59].
 
 [#52]: https://github.com/Yoast/PHPUnit-Polyfills/pull/52
 [#54]: https://github.com/Yoast/PHPUnit-Polyfills/pull/54
@@ -156,6 +210,7 @@ Initial release.
 
 
 [Unreleased]: https://github.com/Yoast/PHPUnit-Polyfills/compare/main...HEAD
+[2.0.0]: https://github.com/Yoast/PHPUnit-Polyfills/compare/1.0.5...2.0.0
 [1.0.5]: https://github.com/Yoast/PHPUnit-Polyfills/compare/1.0.4...1.0.5
 [1.0.4]: https://github.com/Yoast/PHPUnit-Polyfills/compare/1.0.3...1.0.4
 [1.0.3]: https://github.com/Yoast/PHPUnit-Polyfills/compare/1.0.2...1.0.3

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Requirements
 ------------
 
 * PHP 5.6 or higher.
-* [PHPUnit] 5.7 - 9.x (automatically required via Composer).
+* [PHPUnit] 5.7 - 10.x (automatically required via Composer).
 
 [PHPUnit]: https://packagist.org/packages/phpunit/phpunit
 
@@ -45,7 +45,7 @@ Installation
 
 To install this package, run:
 ```bash
-composer require --dev yoast/phpunit-polyfills:"^1.0"
+composer require --dev yoast/phpunit-polyfills:"^2.0"
 ```
 
 To update this package, run:
@@ -65,7 +65,7 @@ Why use the PHPUnit Polyfills?
 
 This library is set up to allow for creating PHPUnit cross-version compatible tests by offering a number of polyfills for functionality which was introduced, split up or renamed in PHPUnit.
 
-### Write your tests for PHPUnit 9.x and run them on PHPUnit 5.7 - 9.x
+### Write your tests for PHPUnit 10.x and run them on PHPUnit 5.7 - 10.x
 
 The polyfills have been setup to allow tests to be _forward_-compatible. What that means is, that your tests can use the assertions supported by the _latest_ PHPUnit version, even when running on older PHPUnit versions.
 
@@ -148,7 +148,7 @@ The polyfills in this library support the first two ways of calling the assertio
 
 For the polyfills to work, a test class is **required** to be a (grand-)child of the PHPUnit native `TestCase` class.
 
-[four ways of calling assertions]: https://docs.phpunit.de/en/9.6/assertions.html#static-vs-non-static-usage-of-assertion-methods
+[four ways of calling assertions]: https://docs.phpunit.de/en/main/assertions.html#static-vs-non-static-usage-of-assertion-methods
 
 ### Use with PHPUnit < 7.5.0
 
@@ -201,7 +201,7 @@ Polyfills the [`TestCase::expectExceptionObject()`] method to test all aspects o
 
 This method was introduced in PHPUnit 6.4.0.
 
-[`TestCase::expectExceptionObject()`]: https://docs.phpunit.de/en/9.6/writing-tests-for-phpunit.html#testing-exceptions
+[`TestCase::expectExceptionObject()`]: https://docs.phpunit.de/en/main/writing-tests-for-phpunit.html#testing-exceptions
 
 #### PHPUnit < 7.5.0: `Yoast\PHPUnitPolyfills\Polyfills\AssertIsType`
 
@@ -219,28 +219,28 @@ Polyfills the following methods:
 
 These methods were introduced in PHPUnit 7.5.0 as alternatives to the `Assert::assertInternalType()` and `Assert::assertNotInternalType()` methods, which were soft deprecated in PHPUnit 7.5.0, hard deprecated (warning) in PHPUnit 8.0.0 and removed in PHPUnit 9.0.0.
 
-[`Assert::assertIsArray()`]:       https://docs.phpunit.de/en/9.6/assertions.html#assertisarray
-[`Assert::assertIsNotArray()`]:    https://docs.phpunit.de/en/9.6/assertions.html#assertisarray
-[`Assert::assertIsBool()`]:        https://docs.phpunit.de/en/9.6/assertions.html#assertisbool
-[`Assert::assertIsNotBool()`]:     https://docs.phpunit.de/en/9.6/assertions.html#assertisbool
-[`Assert::assertIsFloat()`]:       https://docs.phpunit.de/en/9.6/assertions.html#assertisfloat
-[`Assert::assertIsNotFloat()`]:    https://docs.phpunit.de/en/9.6/assertions.html#assertisfloat
-[`Assert::assertIsInt()`]:         https://docs.phpunit.de/en/9.6/assertions.html#assertisint
-[`Assert::assertIsNotInt()`]:      https://docs.phpunit.de/en/9.6/assertions.html#assertisint
-[`Assert::assertIsNumeric()`]:     https://docs.phpunit.de/en/9.6/assertions.html#assertisnumeric
-[`Assert::assertIsNotNumeric()`]:  https://docs.phpunit.de/en/9.6/assertions.html#assertisnumeric
-[`Assert::assertIsObject()`]:      https://docs.phpunit.de/en/9.6/assertions.html#assertisobject
-[`Assert::assertIsNotObject()`]:   https://docs.phpunit.de/en/9.6/assertions.html#assertisobject
-[`Assert::assertIsResource()`]:    https://docs.phpunit.de/en/9.6/assertions.html#assertisresource
-[`Assert::assertIsNotResource()`]: https://docs.phpunit.de/en/9.6/assertions.html#assertisresource
-[`Assert::assertIsString()`]:      https://docs.phpunit.de/en/9.6/assertions.html#assertisstring
-[`Assert::assertIsNotString()`]:   https://docs.phpunit.de/en/9.6/assertions.html#assertisstring
-[`Assert::assertIsScalar()`]:      https://docs.phpunit.de/en/9.6/assertions.html#assertisscalar
-[`Assert::assertIsNotScalar()`]:   https://docs.phpunit.de/en/9.6/assertions.html#assertisscalar
-[`Assert::assertIsCallable()`]:    https://docs.phpunit.de/en/9.6/assertions.html#assertiscallable
-[`Assert::assertIsNotCallable()`]: https://docs.phpunit.de/en/9.6/assertions.html#assertiscallable
-[`Assert::assertIsIterable()`]:    https://docs.phpunit.de/en/9.6/assertions.html#assertisiterable
-[`Assert::assertIsNotIterable()`]: https://docs.phpunit.de/en/9.6/assertions.html#assertisiterable
+[`Assert::assertIsArray()`]:       https://docs.phpunit.de/en/main/assertions.html#assertisarray
+[`Assert::assertIsNotArray()`]:    https://docs.phpunit.de/en/main/assertions.html#assertisarray
+[`Assert::assertIsBool()`]:        https://docs.phpunit.de/en/main/assertions.html#assertisbool
+[`Assert::assertIsNotBool()`]:     https://docs.phpunit.de/en/main/assertions.html#assertisbool
+[`Assert::assertIsFloat()`]:       https://docs.phpunit.de/en/main/assertions.html#assertisfloat
+[`Assert::assertIsNotFloat()`]:    https://docs.phpunit.de/en/main/assertions.html#assertisfloat
+[`Assert::assertIsInt()`]:         https://docs.phpunit.de/en/main/assertions.html#assertisint
+[`Assert::assertIsNotInt()`]:      https://docs.phpunit.de/en/main/assertions.html#assertisint
+[`Assert::assertIsNumeric()`]:     https://docs.phpunit.de/en/main/assertions.html#assertisnumeric
+[`Assert::assertIsNotNumeric()`]:  https://docs.phpunit.de/en/main/assertions.html#assertisnumeric
+[`Assert::assertIsObject()`]:      https://docs.phpunit.de/en/main/assertions.html#assertisobject
+[`Assert::assertIsNotObject()`]:   https://docs.phpunit.de/en/main/assertions.html#assertisobject
+[`Assert::assertIsResource()`]:    https://docs.phpunit.de/en/main/assertions.html#assertisresource
+[`Assert::assertIsNotResource()`]: https://docs.phpunit.de/en/main/assertions.html#assertisresource
+[`Assert::assertIsString()`]:      https://docs.phpunit.de/en/main/assertions.html#assertisstring
+[`Assert::assertIsNotString()`]:   https://docs.phpunit.de/en/main/assertions.html#assertisstring
+[`Assert::assertIsScalar()`]:      https://docs.phpunit.de/en/main/assertions.html#assertisscalar
+[`Assert::assertIsNotScalar()`]:   https://docs.phpunit.de/en/main/assertions.html#assertisscalar
+[`Assert::assertIsCallable()`]:    https://docs.phpunit.de/en/main/assertions.html#assertiscallable
+[`Assert::assertIsNotCallable()`]: https://docs.phpunit.de/en/main/assertions.html#assertiscallable
+[`Assert::assertIsIterable()`]:    https://docs.phpunit.de/en/main/assertions.html#assertisiterable
+[`Assert::assertIsNotIterable()`]: https://docs.phpunit.de/en/main/assertions.html#assertisiterable
 
 #### PHPUnit < 7.5.0: `Yoast\PHPUnitPolyfills\Polyfills\AssertStringContains`
 
@@ -252,10 +252,10 @@ Polyfills the following methods:
 
 These methods were introduced in PHPUnit 7.5.0 as alternatives to using `Assert::assertContains()` and `Assert::assertNotContains()` with string haystacks. Passing string haystacks to these methods was soft deprecated in PHPUnit 7.5.0, hard deprecated (warning) in PHPUnit 8.0.0 and removed in PHPUnit 9.0.0.
 
-[`Assert::assertStringContainsString()`]:                https://docs.phpunit.de/en/9.6/assertions.html#assertstringcontainsstring
-[`Assert::assertStringNotContainsString()`]:             https://docs.phpunit.de/en/9.6/assertions.html#assertstringcontainsstring
-[`Assert::assertStringContainsStringIgnoringCase()`]:    https://docs.phpunit.de/en/9.6/assertions.html#assertstringcontainsstringignoringcase
-[`Assert::assertStringNotContainsStringIgnoringCase()`]: https://docs.phpunit.de/en/9.6/assertions.html#assertstringcontainsstringignoringcase
+[`Assert::assertStringContainsString()`]:                https://docs.phpunit.de/en/main/assertions.html#assertstringcontainsstring
+[`Assert::assertStringNotContainsString()`]:             https://docs.phpunit.de/en/main/assertions.html#assertstringcontainsstring
+[`Assert::assertStringContainsStringIgnoringCase()`]:    https://docs.phpunit.de/en/main/assertions.html#assertstringcontainsstringignoringcase
+[`Assert::assertStringNotContainsStringIgnoringCase()`]: https://docs.phpunit.de/en/main/assertions.html#assertstringcontainsstringignoringcase
 
 #### PHPUnit < 7.5.0: `Yoast\PHPUnitPolyfills\Polyfills\AssertEqualsSpecializations`
 
@@ -268,12 +268,12 @@ Polyfills the following methods:
 
 These methods were introduced in PHPUnit 7.5.0 as alternatives to using `Assert::assertEquals()` and `Assert::assertNotEquals()` with these optional parameters. Passing the respective optional parameters to these methods was soft deprecated in PHPUnit 7.5.0, hard deprecated (warning) in PHPUnit 8.0.0 and removed in PHPUnit 9.0.0.
 
-[`Assert::assertEqualsCanonicalizing()`]:    https://docs.phpunit.de/en/9.6/assertions.html#assertequalscanonicalizing
-[`Assert::assertNotEqualsCanonicalizing()`]: https://docs.phpunit.de/en/9.6/assertions.html#assertequalscanonicalizing
-[`Assert::assertEqualsIgnoringCase()`]:      https://docs.phpunit.de/en/9.6/assertions.html#assertequalsignoringcase
-[`Assert::assertNotEqualsIgnoringCase()`]:   https://docs.phpunit.de/en/9.6/assertions.html#assertequalsignoringcase
-[`Assert::assertEqualsWithDelta()`]:         https://docs.phpunit.de/en/9.6/assertions.html#assertequalswithdelta
-[`Assert::assertNotEqualsWithDelta()`]:      https://docs.phpunit.de/en/9.6/assertions.html#assertequalswithdelta
+[`Assert::assertEqualsCanonicalizing()`]:    https://docs.phpunit.de/en/main/assertions.html#assertequalscanonicalizing
+[`Assert::assertNotEqualsCanonicalizing()`]: https://docs.phpunit.de/en/main/assertions.html#assertequalscanonicalizing
+[`Assert::assertEqualsIgnoringCase()`]:      https://docs.phpunit.de/en/main/assertions.html#assertequalsignoringcase
+[`Assert::assertNotEqualsIgnoringCase()`]:   https://docs.phpunit.de/en/main/assertions.html#assertequalsignoringcase
+[`Assert::assertEqualsWithDelta()`]:         https://docs.phpunit.de/en/main/assertions.html#assertequalswithdelta
+[`Assert::assertNotEqualsWithDelta()`]:      https://docs.phpunit.de/en/main/assertions.html#assertequalswithdelta
 
 #### PHPUnit < 8.4.0: `Yoast\PHPUnitPolyfills\Polyfills\ExpectExceptionMessageMatches`
 
@@ -282,23 +282,28 @@ Polyfills the [`TestCase::expectExceptionMessageMatches()`] method.
 This method was introduced in PHPUnit 8.4.0 to improve the name of the `TestCase::expectExceptionMessageRegExp()` method.
 The `TestCase::expectExceptionMessageRegExp()` method was soft deprecated in PHPUnit 8.4.0, hard deprecated (warning) in PHPUnit 8.5.3 and removed in PHPUnit 9.0.0.
 
-[`TestCase::expectExceptionMessageMatches()`]: https://docs.phpunit.de/en/9.6/writing-tests-for-phpunit.html#testing-exceptions
+[`TestCase::expectExceptionMessageMatches()`]: https://docs.phpunit.de/en/main/writing-tests-for-phpunit.html#testing-exceptions
 
 #### PHPUnit < 8.5.0: `Yoast\PHPUnitPolyfills\Polyfills\AssertFileEqualsSpecializations`
 
 Polyfills the following methods:
-|                                                  |                                                     |
-|--------------------------------------------------|-----------------------------------------------------|
-| `Assert::assertFileEqualsCanonicalizing()`       | `Assert::assertFileNotEqualsCanonicalizing()`       |
-| `Assert::assertFileEqualsIgnoringCase()`         | `Assert::assertFileNotEqualsIgnoringCase()`         |
-| `Assert::assertStringEqualsFileCanonicalizing()` | `Assert::assertStringNotEqualsFileCanonicalizing()` |
-| `Assert::assertStringEqualsFileIgnoringCase()`   | `Assert::assertStringNotEqualsFileIgnoringCase()`   |
+|                                                    |                                                       |
+|----------------------------------------------------|-------------------------------------------------------|
+| [`Assert::assertFileEqualsCanonicalizing()`]       | [`Assert::assertFileNotEqualsCanonicalizing()`]       |
+| [`Assert::assertFileEqualsIgnoringCase()`]         | [`Assert::assertFileNotEqualsIgnoringCase()`]         |
+| [`Assert::assertStringEqualsFileCanonicalizing()`] | [`Assert::assertStringNotEqualsFileCanonicalizing()`] |
+| [`Assert::assertStringEqualsFileIgnoringCase()`]   | [`Assert::assertStringNotEqualsFileIgnoringCase()`]   |
 
 These methods were introduced in PHPUnit 8.5.0 as alternatives to using `Assert::assertFileEquals()` and `Assert::assertFileNotEquals()` with these optional parameters. Passing the respective optional parameters to these methods was hard deprecated in PHPUnit 8.5.0 and removed in PHPUnit 9.0.0.
 
-<!--
-COMMENT: No documentation available (yet) for these assertions on the PHPUnit site.
--->
+[`Assert::assertFileEqualsCanonicalizing()`]:          https://docs.phpunit.de/en/main/assertions.html#assertfileequals
+[`Assert::assertFileNotEqualsCanonicalizing()`]:       https://docs.phpunit.de/en/main/assertions.html#assertfileequals
+[`Assert::assertFileEqualsIgnoringCase()`]:            https://docs.phpunit.de/en/main/assertions.html#assertfileequals
+[`Assert::assertFileNotEqualsIgnoringCase()`]:         https://docs.phpunit.de/en/main/assertions.html#assertfileequals
+[`Assert::assertStringEqualsFileCanonicalizing()`]:    https://docs.phpunit.de/en/main/assertions.html#assertfileequals
+[`Assert::assertStringNotEqualsFileCanonicalizing()`]: https://docs.phpunit.de/en/main/assertions.html#assertfileequals
+[`Assert::assertStringEqualsFileIgnoringCase()`]:      https://docs.phpunit.de/en/main/assertions.html#assertfileequals
+[`Assert::assertStringNotEqualsFileIgnoringCase()`]:   https://docs.phpunit.de/en/main/assertions.html#assertfileequals
 
 #### PHPUnit < 9.0.0: `Yoast\PHPUnitPolyfills\Polyfills\EqualToSpecializations`
 
@@ -325,31 +330,30 @@ Polyfills the following renamed methods:
 * [`Assert::assertDoesNotMatchRegularExpression()`], introduced as alternative for `Assert::assertNotRegExp()`.
 
 These methods were introduced in PHPUnit 9.1.0.
-The original methods these new methods replace were hard deprecated in PHPUnit 9.1.0 and (will be) removed in PHPUnit 10.0.0.
+The original methods these new methods replace were hard deprecated in PHPUnit 9.1.0 and removed in PHPUnit 10.0.0.
 
-[`Assert::assertIsNotReadable()`]:                 https://docs.phpunit.de/en/9.6/assertions.html#assertisreadable
-[`Assert::assertIsNotWritable()`]:                 https://docs.phpunit.de/en/9.6/assertions.html#assertiswritable
-[`Assert::assertDirectoryDoesNotExist()`]:         https://docs.phpunit.de/en/9.6/assertions.html#assertdirectoryexists
-[`Assert::assertDirectoryIsNotReadable()`]:        https://docs.phpunit.de/en/9.6/assertions.html#assertdirectoryisreadable
-[`Assert::assertDirectoryIsNotWritable()`]:        https://docs.phpunit.de/en/9.6/assertions.html#assertdirectoryiswritable
-[`Assert::assertFileDoesNotExist()`]:              https://docs.phpunit.de/en/9.6/assertions.html#assertfileexists
-[`Assert::assertFileIsNotReadable()`]:             https://docs.phpunit.de/en/9.6/assertions.html#assertfileisreadable
-[`Assert::assertFileIsNotWritable()`]:             https://docs.phpunit.de/en/9.6/assertions.html#assertfileiswritable
-[`Assert::assertMatchesRegularExpression()`]:      https://docs.phpunit.de/en/9.6/assertions.html#assertmatchesregularexpression
-[`Assert::assertDoesNotMatchRegularExpression()`]: https://docs.phpunit.de/en/9.6/assertions.html#assertmatchesregularexpression
+[`Assert::assertIsNotReadable()`]:                 https://docs.phpunit.de/en/main/assertions.html#assertisreadable
+[`Assert::assertIsNotWritable()`]:                 https://docs.phpunit.de/en/main/assertions.html#assertiswritable
+[`Assert::assertDirectoryDoesNotExist()`]:         https://docs.phpunit.de/en/main/assertions.html#assertdirectoryexists
+[`Assert::assertDirectoryIsNotReadable()`]:        https://docs.phpunit.de/en/main/assertions.html#assertdirectoryisreadable
+[`Assert::assertDirectoryIsNotWritable()`]:        https://docs.phpunit.de/en/main/assertions.html#assertdirectoryiswritable
+[`Assert::assertFileDoesNotExist()`]:              https://docs.phpunit.de/en/main/assertions.html#assertfileexists
+[`Assert::assertFileIsNotReadable()`]:             https://docs.phpunit.de/en/main/assertions.html#assertfileisreadable
+[`Assert::assertFileIsNotWritable()`]:             https://docs.phpunit.de/en/main/assertions.html#assertfileiswritable
+[`Assert::assertMatchesRegularExpression()`]:      https://docs.phpunit.de/en/main/assertions.html#assertmatchesregularexpression
+[`Assert::assertDoesNotMatchRegularExpression()`]: https://docs.phpunit.de/en/main/assertions.html#assertmatchesregularexpression
 
 #### PHPUnit < 9.3.0: `Yoast\PHPUnitPolyfills\Polyfills\AssertClosedResource`
 
 Polyfills the following methods:
-|                                    |                                       |
-|------------------------------------|---------------------------------------|
-| `Assert::assertIsClosedResource()` | `Assert::assertIsNotClosedResource()` |
+|                                      |                                         |
+|--------------------------------------|-----------------------------------------|
+| [`Assert::assertIsClosedResource()`] | [`Assert::assertIsNotClosedResource()`] |
 
 These methods were introduced in PHPUnit 9.3.0.
 
-<!--
-COMMENT: No documentation available (yet) for these assertions on the PHPUnit site.
--->
+[`Assert::assertIsClosedResource()`]:    https://docs.phpunit.de/en/main/assertions.html#assertisresource
+[`Assert::assertIsNotClosedResource()`]: https://docs.phpunit.de/en/main/assertions.html#assertisresource
 
 Additionally, this trait contains a helper method `shouldClosedResourceAssertionBeSkipped()`.
 
@@ -394,7 +398,7 @@ The `assertObjectEquals()` assertion was introduced in PHPUnit 9.4.0.
 
 [limitations in how this assertion is implemented in PHPUnit]: https://github.com/sebastianbergmann/phpunit/issues/4707
 
-[`Assert::assertObjectEquals()`]: https://docs.phpunit.de/en/9.6/assertions.html#assertobjectequals
+[`Assert::assertObjectEquals()`]: https://docs.phpunit.de/en/main/assertions.html#assertobjectequals
 
 #### PHPUnit < 10.0.0: `Yoast\PHPUnitPolyfills\Polyfills\AssertIgnoringLineEndings`
 
@@ -419,7 +423,7 @@ This method was introduced in PHPUnit 10.0.0.
 
 [`Assert::assertIsList()`]: https://docs.phpunit.de/en/main/assertions.html#assertislist
 
-#### PHPUnit < 10.1.0: `Yoast\PHPUnitPolyfills\Polyfills\AssertIsList`
+#### PHPUnit < 10.1.0: `Yoast\PHPUnitPolyfills\Polyfills\AssertObjectProperty`
 
 Polyfills the following method:
 |                                       |                                          |
@@ -428,7 +432,7 @@ Polyfills the following method:
 
 These methods were introduced in PHPUnit 10.1.0 as alternatives to the `Assert::assertObjectHasAttribute()` and `Assert::assertObjectNotHasAttribute()` methods, which were hard deprecated (warning) in PHPUnit 9.6.1 and removed in PHPUnit 10.0.0.
 
-[`Assert::assertObjectHasProperty()`]: https://docs.phpunit.de/en/main/assertions.html#assertObjectHasProperty
+[`Assert::assertObjectHasProperty()`]:    https://docs.phpunit.de/en/main/assertions.html#assertObjectHasProperty
 [`Assert::assertObjectNotHasProperty()`]: https://docs.phpunit.de/en/main/assertions.html#assertObjectHasProperty
 
 
@@ -469,7 +473,7 @@ self::assertSame( $propertyName, self::getProperty( $objInstance, $propertyName 
 PHPUnit 8.0.0 introduced a `void` return type declaration to the ["fixture" methods] - `setUpBeforeClass()`, `setUp()`, `tearDown()` and `tearDownAfterClass()`.
 As the `void` return type was not introduced until PHP 7.1, this makes it more difficult to create cross-version compatible tests when using fixtures, due to signature mismatches.
 
-["fixture" methods]: https://docs.phpunit.de/en/9.6/fixtures.html
+["fixture" methods]: https://docs.phpunit.de/en/main/fixtures.html
 
 This library contains two basic `TestCase` options to overcome this issue.
 
@@ -533,10 +537,10 @@ This `TestCase` overcomes the signature mismatch by using the PHPUnit `@before[C
 When using this TestCase, overloaded fixture methods need to use the [`@beforeClass`], [`@before`], [`@after`] and [`@afterClass`] annotations.
 The naming of the overloaded methods is open as long as the method names don't conflict with the PHPUnit native method names.
 
-[`@beforeClass`]: https://docs.phpunit.de/en/9.6/annotations.html#beforeclass
-[`@before`]:      https://docs.phpunit.de/en/9.6/annotations.html#before
-[`@after`]:       https://docs.phpunit.de/en/9.6/annotations.html#after
-[`@afterClass`]:  https://docs.phpunit.de/en/9.6/annotations.html#afterclass
+[`@beforeClass`]: https://docs.phpunit.de/en/main/annotations.html#beforeclass
+[`@before`]:      https://docs.phpunit.de/en/main/annotations.html#before
+[`@after`]:       https://docs.phpunit.de/en/main/annotations.html#after
+[`@afterClass`]:  https://docs.phpunit.de/en/main/annotations.html#afterclass
 
 ```php
 use Yoast\PHPUnitPolyfills\TestCases\XTestCase;
@@ -581,6 +585,16 @@ class MyTest extends XTestCase {
 ```
 
 ### TestListener
+
+> :warning: **Important** :warning:
+>
+> The TestListener polyfill in PHPUnit Polyfills 2.0 is [not (yet) compatible with PHPUnit 10.0.0][polyfill-ticket].
+>
+> If you need the TestListener polyfill, it is recommended to stay on the PHPUnit Polyfills 1.x series for the time being and to watch and upvote the [related ticket][polyfill-ticket].
+>
+> The below documentation is for the PHPUnit 5.x-9.x TestListener polyfill implementation.
+
+[polyfill-ticket]: https://github.com/Yoast/PHPUnit-Polyfills/issues/128
 
 The method signatures in the PHPUnit `TestListener` interface have changed a number of times across versions.
 Additionally, the use of the TestListener principle has been deprecated in PHPUnit 7 in favour of using the [TestRunner hook interfaces](https://docs.phpunit.de/en/7.5/extending-phpunit.html#extending-the-testrunner).

--- a/phpunitpolyfills-autoload.php
+++ b/phpunitpolyfills-autoload.php
@@ -19,7 +19,7 @@ if ( \class_exists( 'Yoast\PHPUnitPolyfills\Autoload', false ) === false ) {
 		 *
 		 * @var string
 		 */
-		const VERSION = '2.0.0-dev';
+		const VERSION = '2.0.0';
 
 		/**
 		 * Loads a class.


### PR DESCRIPTION
### README: update

Includes:
* Adding a warning about the TestListener polyfill not (yet) being compatible with PHPUnit 10.
* Adding links to the documentation of some assertions, which are documented in the PHPUnit 10 documentation, but were previously undocumented.
* Updating all links to the PHPUnit documentation to point to the PHPUnit 10 docs instead of the PHPUnit 9 docs.

### Changelog for the 2.0.0 release

Includes updating the `VERSION` constant in the `Autoload` class.

Includes minor punctuation fixes to older changelog entries.