### PR TITLE
Dependabot: set target branch to 1.x

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,7 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 5
+    target-branch: "1.x"
     commit-message:
       prefix: "GH Actions:"
     labels:
@@ -24,6 +25,7 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 5 # Set to 0 to (temporarily) disable.
+    target-branch: "1.x"
     versioning-strategy: widen
     commit-message:
       prefix: "Composer:"


### PR DESCRIPTION
... as most updates are needed for both the 1.x, as well as the 2.x branch.