### PR TITLE
Composer: normalize the file + add script descriptions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,76 +1,82 @@
 {
-    "name": "yoast/phpunit-polyfills",
-    "description": "Set of polyfills for changed PHPUnit functionality to allow for creating PHPUnit cross-version compatible tests",
-    "type": "library",
-    "keywords": [ "phpunit", "polyfill", "testing" ],
-    "license": "BSD-3-Clause",
-    "homepage": "https://github.com/Yoast/PHPUnit-Polyfills",
-    "authors": [
-        {
-            "name"    : "Team Yoast",
-            "email"   : "support@yoast.com",
-            "homepage": "https://yoast.com"
-        },
-        {
-            "name"    : "Contributors",
-            "homepage": "https://github.com/Yoast/PHPUnit-Polyfills/graphs/contributors"
-        }
-    ],
-    "support": {
-        "issues": "https://github.com/Yoast/PHPUnit-Polyfills/issues",
-        "source": "https://github.com/Yoast/PHPUnit-Polyfills"
-    },
-    "minimum-stability": "dev",
-    "prefer-stable": true,
-    "require": {
-        "php": ">=5.4",
-        "phpunit/phpunit": "^4.8.36 || ^5.7.21 || ^6.0 || ^7.0 || ^8.0 || ^9.0"
-    },
-    "require-dev": {
-        "yoast/yoastcs": "^2.3.0"
-    },
-    "config": {
-        "allow-plugins": {
-            "dealerdirect/phpcodesniffer-composer-installer": true
-        }
-    },
-    "autoload": {
-        "files": ["phpunitpolyfills-autoload.php"]
-    },
-    "autoload-dev" : {
-        "psr-4": {
-            "Yoast\\PHPUnitPolyfills\\Tests\\": "tests/"
-        }
-    },
-    "extra": {
-        "branch-alias": {
-            "dev-main": "2.x-dev"
-        }
-    },
-    "scripts": {
-        "lint7": [
-            "@php ./vendor/php-parallel-lint/php-parallel-lint/parallel-lint . -e php --show-deprecated --exclude vendor --exclude .git --exclude src/Exceptions/Error.php --exclude src/Exceptions/TypeError.php --exclude tests/Polyfills/Fixtures/ValueObjectUnion.php --exclude tests/Polyfills/Fixtures/ValueObjectUnionNoReturnType.php"
-        ],
-        "lint-lt70": [
-            "@php ./vendor/php-parallel-lint/php-parallel-lint/parallel-lint . -e php --show-deprecated --exclude vendor --exclude .git --exclude src/TestCases/TestCasePHPUnitGte8.php --exclude src/TestListeners/TestListenerDefaultImplementationPHPUnitGte7.php --exclude tests/Polyfills/Fixtures/ChildValueObject.php --exclude tests/Polyfills/Fixtures/ValueObject.php --exclude tests/Polyfills/Fixtures/ValueObjectUnion.php --exclude tests/Polyfills/Fixtures/ValueObjectUnionNoReturnType.php"
-        ],
-        "lint-gte80": [
-            "@php ./vendor/php-parallel-lint/php-parallel-lint/parallel-lint . -e php --show-deprecated --exclude vendor --exclude .git"
-        ],
-        "check-cs": [
-            "@php ./vendor/squizlabs/php_codesniffer/bin/phpcs --runtime-set testVersion 5.4-"
-        ],
-        "fix-cs": [
-            "@php ./vendor/squizlabs/php_codesniffer/bin/phpcbf"
-        ],
-        "test": [
-            "@php ./vendor/phpunit/phpunit/phpunit --no-coverage"
-        ],
-        "coverage": [
-            "@php ./vendor/phpunit/phpunit/phpunit"
-        ],
-        "coverage-local": [
-            "@php ./vendor/phpunit/phpunit/phpunit --coverage-html ./build/coverage-html"
-        ]
-    }
+	"name": "yoast/phpunit-polyfills",
+	"description": "Set of polyfills for changed PHPUnit functionality to allow for creating PHPUnit cross-version compatible tests",
+	"license": "BSD-3-Clause",
+	"type": "library",
+	"keywords": [
+		"phpunit",
+		"polyfill",
+		"testing"
+	],
+	"authors": [
+		{
+			"name": "Team Yoast",
+			"email": "support@yoast.com",
+			"homepage": "https://yoast.com"
+		},
+		{
+			"name": "Contributors",
+			"homepage": "https://github.com/Yoast/PHPUnit-Polyfills/graphs/contributors"
+		}
+	],
+	"homepage": "https://github.com/Yoast/PHPUnit-Polyfills",
+	"support": {
+		"issues": "https://github.com/Yoast/PHPUnit-Polyfills/issues",
+		"source": "https://github.com/Yoast/PHPUnit-Polyfills"
+	},
+	"require": {
+		"php": ">=5.4",
+		"phpunit/phpunit": "^4.8.36 || ^5.7.21 || ^6.0 || ^7.0 || ^8.0 || ^9.0"
+	},
+	"require-dev": {
+		"yoast/yoastcs": "^2.3.0"
+	},
+	"minimum-stability": "dev",
+	"prefer-stable": true,
+	"autoload": {
+		"files": [
+			"phpunitpolyfills-autoload.php"
+		]
+	},
+	"autoload-dev": {
+		"psr-4": {
+			"Yoast\\PHPUnitPolyfills\\Tests\\": "tests/"
+		}
+	},
+	"config": {
+		"allow-plugins": {
+			"dealerdirect/phpcodesniffer-composer-installer": true
+		}
+	},
+	"extra": {
+		"branch-alias": {
+			"dev-main": "2.x-dev"
+		}
+	},
+	"scripts": {
+		"lint7": [
+			"@php ./vendor/php-parallel-lint/php-parallel-lint/parallel-lint . -e php --show-deprecated --exclude vendor --exclude .git --exclude src/Exceptions/Error.php --exclude src/Exceptions/TypeError.php --exclude tests/Polyfills/Fixtures/ValueObjectUnion.php --exclude tests/Polyfills/Fixtures/ValueObjectUnionNoReturnType.php"
+		],
+		"lint-lt70": [
+			"@php ./vendor/php-parallel-lint/php-parallel-lint/parallel-lint . -e php --show-deprecated --exclude vendor --exclude .git --exclude src/TestCases/TestCasePHPUnitGte8.php --exclude src/TestListeners/TestListenerDefaultImplementationPHPUnitGte7.php --exclude tests/Polyfills/Fixtures/ChildValueObject.php --exclude tests/Polyfills/Fixtures/ValueObject.php --exclude tests/Polyfills/Fixtures/ValueObjectUnion.php --exclude tests/Polyfills/Fixtures/ValueObjectUnionNoReturnType.php"
+		],
+		"lint-gte80": [
+			"@php ./vendor/php-parallel-lint/php-parallel-lint/parallel-lint . -e php --show-deprecated --exclude vendor --exclude .git"
+		],
+		"check-cs": [
+			"@php ./vendor/squizlabs/php_codesniffer/bin/phpcs --runtime-set testVersion 5.4-"
+		],
+		"fix-cs": [
+			"@php ./vendor/squizlabs/php_codesniffer/bin/phpcbf"
+		],
+		"test": [
+			"@php ./vendor/phpunit/phpunit/phpunit --no-coverage"
+		],
+		"coverage": [
+			"@php ./vendor/phpunit/phpunit/phpunit"
+		],
+		"coverage-local": [
+			"@php ./vendor/phpunit/phpunit/phpunit --coverage-html ./build/coverage-html"
+		]
+	}
 }

--- a/composer.json
+++ b/composer.json
@@ -78,5 +78,15 @@
 		"coverage-local": [
 			"@php ./vendor/phpunit/phpunit/phpunit --coverage-html ./build/coverage-html"
 		]
+	},
+	"scripts-descriptions": {
+		"lint7": "Check the PHP files for parse errors. (PHP 7.x)",
+		"lint-lt70": "Check the PHP files for parse errors. (PHP < 7.0)",
+		"lint-gte80": "Check the PHP files for parse errors. (PHP 8.0+)",
+		"check-cs": "Check the PHP files for code style violations and best practices.",
+		"fix-cs": "Auto-fix code style violations in the PHP files.",
+		"test": "Run the unit tests without code coverage.",
+		"coverage": "Run the unit tests with code coverage.",
+		"coverage-local": "Run the unit tests with code coverage writing an HTML coverage report to a \"/build/coverage-html\" directory."
 	}
 }


### PR DESCRIPTION
### Composer: normalize the file

Well, mostly (scripts are not alphabetized, but still grouped by task).

Note: this is done as a one-time only action. The normalize script will **_not_** be run in CI to enforce normalization.

Style has been standardized to `--indent-style=tab --indent-size=1`.

Ref: https://github.com/ergebnis/composer-normalize

### Composer: add script descriptions

These descriptions will be used when a list of the available scripts is requested on the command-line using the `composer list` or `composer run -l` commands.

These descriptions also help document the different scripts for the maintainers of the `composer.json` file.

Ref: https://getcomposer.org/doc/articles/scripts.md#custom-descriptions-