### PR TITLE
Tests: tweaks to work round PHP 8.4 deprecation

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -65,10 +65,18 @@ jobs:
         if: ${{ matrix.php < 7.0 }}
         run: composer lint-lt70
 
-      - name: "Lint PHP files against parse errors - PHP 7.x"
-        if: ${{ startsWith( matrix.php, '7' ) }}
+      - name: "Lint PHP files against parse errors - PHP 7.0"
+        if: ${{ matrix.php == '7.0' }}
+        run: composer lint70
+
+      - name: "Lint PHP files against parse errors - PHP 7.1 - 7.4"
+        if: ${{ startsWith( matrix.php, '7' ) && matrix.php != '7.0' }}
         run: composer lint7
 
-      - name: "Lint PHP files against parse errors - PHP >= 8.0"
-        if: ${{ matrix.php >= 8.0 }}
+      - name: "Lint PHP files against parse errors - PHP 8.0 - 8.3"
+        if: ${{ matrix.php >= 8.0 && matrix.php < 8.4 }}
         run: composer lint-gte80
+
+      - name: "Lint PHP files against parse errors - PHP >= 8.4"
+        if: ${{ matrix.php >= 8.4 }}
+        run: composer lint-gte84

--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -193,6 +193,9 @@
 		<exclude-pattern>/tests/Polyfills/Fixtures/ValueObjectUnion\.php$</exclude-pattern>
 		<exclude-pattern>/tests/Polyfills/Fixtures/ValueObjectUnionNoReturnType\.php$</exclude-pattern>
 	</rule>
+	<rule ref="PHPCompatibility.FunctionDeclarations.NewNullableTypes.typeDeclarationFound">
+		<exclude-pattern>/tests/Polyfills/Fixtures/ValueObject\.php$</exclude-pattern>
+	</rule>
 	<rule ref="PHPCompatibility.Operators.NewOperators.t_spaceshipFound">
 		<exclude-pattern>/tests/Polyfills/Fixtures/ValueObject\.php$</exclude-pattern>
 	</rule>

--- a/composer.json
+++ b/composer.json
@@ -60,11 +60,17 @@
 		"lint7": [
 			"@php ./vendor/php-parallel-lint/php-parallel-lint/parallel-lint . -e php --show-deprecated --exclude vendor --exclude .git --exclude src/Exceptions/Error.php --exclude src/Exceptions/TypeError.php --exclude tests/Polyfills/Fixtures/ValueObjectUnion.php --exclude tests/Polyfills/Fixtures/ValueObjectUnionNoReturnType.php"
 		],
+		"lint70": [
+			"@php ./vendor/php-parallel-lint/php-parallel-lint/parallel-lint . -e php --show-deprecated --exclude vendor --exclude .git --exclude src/Exceptions/Error.php --exclude src/Exceptions/TypeError.php --exclude tests/Polyfills/Fixtures/ValueObject.php --exclude tests/Polyfills/Fixtures/ValueObjectUnion.php --exclude tests/Polyfills/Fixtures/ValueObjectUnionNoReturnType.php"
+		],
 		"lint-lt70": [
 			"@php ./vendor/php-parallel-lint/php-parallel-lint/parallel-lint . -e php --show-deprecated --exclude vendor --exclude .git --exclude src/TestCases/TestCasePHPUnitGte8.php --exclude src/TestListeners/TestListenerDefaultImplementationPHPUnitGte7.php --exclude tests/Polyfills/Fixtures/ChildValueObject.php --exclude tests/Polyfills/Fixtures/ValueObject.php --exclude tests/Polyfills/Fixtures/ValueObjectUnion.php --exclude tests/Polyfills/Fixtures/ValueObjectUnionNoReturnType.php"
 		],
 		"lint-gte80": [
 			"@php ./vendor/php-parallel-lint/php-parallel-lint/parallel-lint . -e php --show-deprecated --exclude vendor --exclude .git"
+		],
+		"lint-gte84": [
+			"@php ./vendor/php-parallel-lint/php-parallel-lint/parallel-lint . -e php --show-deprecated --exclude vendor --exclude .git  --exclude tests/Polyfills/Fixtures/ValueObjectNoReturnType.php"
 		],
 		"check-cs": [
 			"@php ./vendor/squizlabs/php_codesniffer/bin/phpcs --runtime-set testVersion 5.4-"
@@ -83,9 +89,11 @@
 		]
 	},
 	"scripts-descriptions": {
-		"lint7": "Check the PHP files for parse errors. (PHP 7.x)",
+		"lint7": "Check the PHP files for parse errors. (PHP 7.1 - 7.4)",
+		"lint70": "Check the PHP files for parse errors. (PHP 7.0)",
 		"lint-lt70": "Check the PHP files for parse errors. (PHP < 7.0)",
-		"lint-gte80": "Check the PHP files for parse errors. (PHP 8.0+)",
+		"lint-gte80": "Check the PHP files for parse errors. (PHP 8.0 - 8.3)",
+		"lint-gte84": "Check the PHP files for parse errors. (PHP 8.4+)",
 		"check-cs": "Check the PHP files for code style violations and best practices.",
 		"fix-cs": "Auto-fix code style violations in the PHP files.",
 		"test": "Run the unit tests without code coverage.",

--- a/tests/Polyfills/AssertObjectEqualsPHPUnitLt940Test.php
+++ b/tests/Polyfills/AssertObjectEqualsPHPUnitLt940Test.php
@@ -23,6 +23,8 @@ use Yoast\PHPUnitPolyfills\Tests\Polyfills\Fixtures\ValueObjectUnionNoReturnType
  * would make a test incompatible with the PHPUnit 9.4.0+ native implementation
  * of the assertion.
  *
+ * These tests are not run on PHP 8.4+ as only PHPUnit 9.5+ is compatible with PHP 8.4.
+ *
  * @covers \Yoast\PHPUnitPolyfills\Polyfills\AssertObjectEquals
  */
 final class AssertObjectEqualsPHPUnitLt940Test extends TestCase {
@@ -53,6 +55,10 @@ final class AssertObjectEqualsPHPUnitLt940Test extends TestCase {
 	public function maybeSkipTest() {
 		if ( \version_compare( PHPUnit_Version::id(), '9.4.0', '>=' ) ) {
 			$this->markTestSkipped( 'This test can not be run with the PHPUnit native implementation of assertObjectEquals()' );
+		}
+
+		if ( \version_compare( \PHP_VERSION_ID, '8.3.99', '>' ) ) {
+			$this->markTestSkipped( 'This test can not be run on PHP 8.4 or higher as PHPUnit < 9.4.0 is not compatible with PHP 8.4' );
 		}
 	}
 

--- a/tests/Polyfills/AssertObjectEqualsTest.php
+++ b/tests/Polyfills/AssertObjectEqualsTest.php
@@ -18,12 +18,16 @@ use Yoast\PHPUnitPolyfills\Tests\Polyfills\Fixtures\ValueObjectUnion;
  * Due to the use of return types in the classes under test (fixtures), these
  * tests can only run on PHP 7.0 and higher.
  *
+ * And due to the implicitly nullable parameter deprecation in PHP 8.4 requiring a
+ * nullable type for one of the tests, the minimum PHP version for running this
+ * version of the tests has been set to PHP 7.1.
+ *
  * The `AssertObjectEqualsPHPUnitLt940Test` class mirrors this test class
- * and tests the polyfill method for PHP < 7.0.
+ * and tests the polyfill method for PHP < 7.1.
  *
  * @covers \Yoast\PHPUnitPolyfills\Polyfills\AssertObjectEquals
  *
- * @requires PHP 7.0
+ * @requires PHP 7.1
  */
 final class AssertObjectEqualsTest extends TestCase {
 

--- a/tests/Polyfills/Fixtures/ValueObject.php
+++ b/tests/Polyfills/Fixtures/ValueObject.php
@@ -66,7 +66,7 @@ class ValueObject {
 	 *
 	 * @return bool
 	 */
-	public function equalsParamNotRequired( self $other = null ): bool {
+	public function equalsParamNotRequired( ?self $other = null ): bool {
 		return ( $this->value === $other->value );
 	}
 

--- a/tests/TestCases/TestCaseTestTrait.php
+++ b/tests/TestCases/TestCaseTestTrait.php
@@ -169,7 +169,7 @@ trait TestCaseTestTrait {
 	/**
 	 * Verify availability of trait polyfilled PHPUnit methods [14].
 	 *
-	 * @requires PHP 7.0
+	 * @requires PHP 7.1
 	 *
 	 * @return void
 	 */


### PR DESCRIPTION
PHP 8.4 deprecates implicitly nullable parameters, i.e. typed parameter with a `null` default value, which are not explicitly declared as nullable.

The `ValueObject` fixture used in these tests used one such implicitly nullable parameters.

The tests for the `AssertObjectEquals` trait already needed two test classes to allow the method to be fully tests cross-version:
* One set which was run on PHPUnit < 9.4.0.
* One set which runs against PHP 7.0+.

As the nullability operator was introduced in PHP 7.1 and the particular test affected _does_ need to be typed to still test what it is supposed to test, I'm changing the requirements both test sets:
* The requirement for the first set of tests will now be PHPUnit < 9.4.0 AND PHP < 8.4.
* The requirement for the second set of test will now be PHP 7.1+.

This way the tests still covers the trait sufficiently.

_Note: the trait itself is not affected by the deprecation._