### PR TITLE
AssertClosedResource: fix compatibility with PHPUnit 8/9 PHAR files

### DIFF
--- a/src/Polyfills/AssertClosedResource.php
+++ b/src/Polyfills/AssertClosedResource.php
@@ -2,7 +2,8 @@
 
 namespace Yoast\PHPUnitPolyfills\Polyfills;
 
-use PHPUnit\SebastianBergmann\Exporter\Exporter as Exporter_In_Phar;
+use PHPUnit\SebastianBergmann\Exporter\Exporter as Exporter_In_Phar_Old;
+use PHPUnitPHAR\SebastianBergmann\Exporter\Exporter as Exporter_In_Phar;
 use SebastianBergmann\Exporter\Exporter;
 use Yoast\PHPUnitPolyfills\Helpers\ResourceHelper;
 
@@ -25,7 +26,7 @@ trait AssertClosedResource {
 	 * @return void
 	 */
 	public static function assertIsClosedResource( $actual, $message = '' ) {
-		$exporter = \class_exists( 'SebastianBergmann\Exporter\Exporter' ) ? new Exporter() : new Exporter_In_Phar();
+		$exporter = self::getPHPUnitExporterObject();
 		$msg      = \sprintf( 'Failed asserting that %s is of type "resource (closed)"', $exporter->export( $actual ) );
 
 		if ( $message !== '' ) {
@@ -44,7 +45,7 @@ trait AssertClosedResource {
 	 * @return void
 	 */
 	public static function assertIsNotClosedResource( $actual, $message = '' ) {
-		$exporter = \class_exists( 'SebastianBergmann\Exporter\Exporter' ) ? new Exporter() : new Exporter_In_Phar();
+		$exporter = self::getPHPUnitExporterObject();
 		$type     = $exporter->export( $actual );
 		if ( $type === 'NULL' ) {
 			$type = 'resource (closed)';
@@ -76,5 +77,24 @@ trait AssertClosedResource {
 	 */
 	public static function shouldClosedResourceAssertionBeSkipped( $actual ) {
 		return ( ResourceHelper::isResourceStateReliable( $actual ) === false );
+	}
+
+	/**
+	 * Helper function to obtain an instance of the Exporter class.
+	 *
+	 * @return SebastianBergmann\Exporter\Exporter|PHPUnitPHAR\SebastianBergmann\Exporter\Exporter|PHPUnit\SebastianBergmann\Exporter\Exporter
+	 */
+	private static function getPHPUnitExporterObject() {
+		if ( \class_exists( 'SebastianBergmann\Exporter\Exporter' ) ) {
+			// Composer install or really old PHAR files.
+			return new Exporter();
+		}
+		elseif ( \class_exists( 'PHPUnitPHAR\SebastianBergmann\Exporter\Exporter' ) ) {
+			// PHPUnit PHAR file for 8.5.38+, 9.6.19+, 10.5.17+ and 11.0.10+.
+			return new Exporter_In_Phar();
+		}
+
+		// PHPUnit PHAR file for < 8.5.38, < 9.6.19, < 10.5.17 and < 11.0.10.
+		return new Exporter_In_Phar_Old();
 	}
 }


### PR DESCRIPTION
PHPUnit 8.5..38 and 9.6.19 contain a change in the PHAR files. In particular, a change in how external dependencies included in the packaged PHAR files are prefixed to prevent conflicts with potentially Composer installed dependencies on the same packages.

In practice, the prefix for these external dependencies which is being added when the PHAR is being build has changed from `PHPUnit\\` to `PHPUnitPHAR\\`.

This impacts the `AssertClosedResource` polyfill which uses the `SebastianBergmann\Exporter\Exporter` class from the external `Exporter` dependency.

This commit fixes the issue.

Refs:
* https://github.com/sebastianbergmann/phpunit/releases/tag/8.5.38
* https://github.com/sebastianbergmann/phpunit/releases/tag/9.6.19