### PR TITLE
Changelog for the 1.1.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ This projects adheres to [Keep a CHANGELOG](http://keepachangelog.com/) and uses
 
 _Nothing yet._
 
+## [1.1.1] - 2024-04-05
+
+### Added
+* Compatibility fix for running tests using a PHPUnit PHAR file for PHPUnit 8.5.38+ and PHPUnit 9.6.19+. PR [#161].
+
+### Changed
+* General housekeeping.
+
+[#161]: https://github.com/Yoast/PHPUnit-Polyfills/pull/161
+
+
 ## [1.1.0] - 2023-08-19
 
 ### Added
@@ -166,7 +177,8 @@ As of version 2.15.0 of the `shivammathur/setup-php` action for GitHub Actions, 
 Initial release.
 
 
-[Unreleased]: https://github.com/Yoast/PHPUnit-Polyfills/compare/main...HEAD
+[Unreleased]: https://github.com/Yoast/PHPUnit-Polyfills/compare/1.x...HEAD
+[1.1.1]: https://github.com/Yoast/PHPUnit-Polyfills/compare/1.1.0...1.1.1
 [1.1.0]: https://github.com/Yoast/PHPUnit-Polyfills/compare/1.0.5...1.1.0
 [1.0.5]: https://github.com/Yoast/PHPUnit-Polyfills/compare/1.0.4...1.0.5
 [1.0.4]: https://github.com/Yoast/PHPUnit-Polyfills/compare/1.0.3...1.0.4

--- a/phpunitpolyfills-autoload.php
+++ b/phpunitpolyfills-autoload.php
@@ -17,7 +17,7 @@ if ( \class_exists( 'Yoast\PHPUnitPolyfills\Autoload', false ) === false ) {
 		 *
 		 * @var string
 		 */
-		const VERSION = '1.1.0';
+		const VERSION = '1.1.1';
 
 		/**
 		 * Loads a class.


### PR DESCRIPTION
Includes updating the `VERSION` constant in the `Autoload` class.

---

# Release checklist

## Functional
- [x] Confirm that the most recent PHPUnit changelogs have been checked and that the library is still feature complete for those versions supported within the PHPUnit version constraints.
- [x] Update the `VERSION` constant in the `phpunitpolyfills-autoload.php` file. - PR #165
- [x] Composer: check if any dependencies/version constraints need updating. - PR #163 

## Release
- [x] Add changelog for the release - PR #165
    Verify that a release link at the bottom of the `CHANGELOG.md` file has been added.
- [ ] Merge this PR.
- [ ] Make sure all CI builds are green.
- [ ] Tag the release (careful, GH defaults to `2.x`!).
- [ ] Create a release from the tag (careful, GH defaults to `2.x`!) & copy & paste the changelog to it.
    Make sure to copy the links to the issues and the links to the GH usernames from the bottom of the changelog!
- [ ] Close the milestone.
- [ ] Open a new milestone for the next release.
- [ ] If any open PRs/issues which were milestoned for the release did not make it into the release, update their milestone.

## Announce
- [ ] Tweet about the release.
- [ ] Toot about the release.
