### PR TITLE
README/GH Actions: tweak markdown tables

### DIFF
--- a/.github/workflows/markdown.yml
+++ b/.github/workflows/markdown.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Set up node and enable caching of dependencies
         uses: actions/setup-node@v4
         with:
-          node-version: '16'
+          node-version: '20'
 
       # To make the command available on CLI, it needs to be installed globally.
       - name: Install Remark CLI globally

--- a/.remarkrc
+++ b/.remarkrc
@@ -31,7 +31,7 @@
     "remark-lint-no-unneeded-full-reference-link",
     "remark-lint-no-unused-definitions",
     ["remark-lint-strikethrough-marker", "~~"],
-    ["remark-lint-table-cell-padding", "consistent"],
+    ["remark-lint-table-cell-padding", "padded"],
     "remark-lint-heading-whitespace",
     "remark-lint-list-item-punctuation",
     "remark-lint-match-punctuation",

--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ To prevent _"conflicting method names"_ errors when a trait is `use`d multiple t
 You will need to make sure to `use` any additional traits needed for the polyfills to work.
 
 | PHPUnit   | When `use`-ing this trait       | You also need to `use` this trait |
-|-----------|---------------------------------|-----------------------------------|
+| --------- | ------------------------------- | --------------------------------- |
 | 4.8 < 5.2 | `ExpectExceptionObject`         | `ExpectException`                 |
 | 4.8 < 5.2 | `ExpectPHPException`            | `ExpectException`                 |
 | 4.8 < 5.2 | `ExpectExceptionMessageMatches` | `ExpectException`                 |
@@ -199,7 +199,7 @@ Features
 
 Polyfills the following methods:
 |                            |                              |                         |
-|----------------------------|------------------------------|-------------------------|
+| -------------------------- | ---------------------------- | ----------------------- |
 | [`Assert::assertFinite()`] | [`Assert::assertInfinite()`] | [`Assert::assertNan()`] |
 
 These methods were introduced in PHPUnit 5.0.0.
@@ -212,7 +212,7 @@ These methods were introduced in PHPUnit 5.0.0.
 
 Polyfills the following methods:
 |                                     |                                              |
-|-------------------------------------|----------------------------------------------|
+| ----------------------------------- | -------------------------------------------- |
 | [`TestCase::expectException()`]     | [`TestCase::expectExceptionMessage()`]       |
 | [`TestCase::expectExceptionCode()`] | [`TestCase::expectExceptionMessageRegExp()`] |
 
@@ -228,7 +228,7 @@ Both these methods were removed in PHPUnit 6.0.0.
 
 Polyfills the following methods:
 |                                         |                                            |
-|-----------------------------------------|--------------------------------------------|
+| --------------------------------------- | ------------------------------------------ |
 | [`Assert::assertIsReadable()`]          | [`Assert::assertNotIsReadable()`]          |
 | [`Assert::assertIsWritable()`]          | [`Assert::assertNotIsWritable()`]          |
 | [`Assert::assertDirectoryExists()`]     | [`Assert::assertDirectoryNotExists()`]     |
@@ -266,7 +266,7 @@ This method was introduced in PHPUnit 6.4.0.
 
 Polyfills the following methods:
 |                                   |                                   |                                 |
-|-----------------------------------|-----------------------------------|---------------------------------|
+| --------------------------------- | --------------------------------- | ------------------------------- |
 | [`Assert::assertIsArray()`]       | [`Assert::assertIsBool()`]        | [`Assert::assertIsFloat()`]     |
 | [`Assert::assertIsInt()`]         | [`Assert::assertIsNumeric()`]     | [`Assert::assertIsObject()`]    |
 | [`Assert::assertIsResource()`]    | [`Assert::assertIsString()`]      | [`Assert::assertIsScalar()`]    |
@@ -305,7 +305,7 @@ These methods were introduced in PHPUnit 7.5.0 as alternatives to the `Assert::a
 
 Polyfills the following methods:
 |                                                      |                                                         |
-|------------------------------------------------------|---------------------------------------------------------|
+| ---------------------------------------------------- | ------------------------------------------------------- |
 | [`Assert::assertStringContainsString()`]             | [`Assert::assertStringNotContainsString()`]             |
 | [`Assert::assertStringContainsStringIgnoringCase()`] | [`Assert::assertStringNotContainsStringIgnoringCase()`] |
 
@@ -320,7 +320,7 @@ These methods were introduced in PHPUnit 7.5.0 as alternatives to using `Assert:
 
 Polyfills the following methods:
 |                                          |                                             |
-|------------------------------------------|---------------------------------------------|
+| ---------------------------------------- | ------------------------------------------- |
 | [`Assert::assertEqualsCanonicalizing()`] | [`Assert::assertNotEqualsCanonicalizing()`] |
 | [`Assert::assertEqualsIgnoringCase()`]   | [`Assert::assertNotEqualsIgnoringCase()`]   |
 | [`Assert::assertEqualsWithDelta()`]      | [`Assert::assertNotEqualsWithDelta()`]      |
@@ -338,7 +338,7 @@ These methods were introduced in PHPUnit 7.5.0 as alternatives to using `Assert:
 
 Polyfills the following methods:
 |                                     |                                |                                       |
-|-------------------------------------|--------------------------------|---------------------------------------|
+| ----------------------------------- | ------------------------------ | ------------------------------------- |
 | `TestCase::`[`expectError()`]       | [`expectErrorMessage()`]       | [`expectErrorMessageMatches()`]       |
 | `TestCase::`[`expectWarning()`]     | [`expectWarningMessage()`]     | [`expectWarningMessageMatches()`]     |
 | `TestCase::`[`expectNotice()`]      | [`expectNoticeMessage()`]      | [`expectNoticeMessageMatches()`]      |
@@ -373,7 +373,7 @@ The `TestCase::expectExceptionMessageRegExp()` method was soft deprecated in PHP
 
 Polyfills the following methods:
 |                                                  |                                                     |
-|--------------------------------------------------|-----------------------------------------------------|
+| ------------------------------------------------ | --------------------------------------------------- |
 | `Assert::assertFileEqualsCanonicalizing()`       | `Assert::assertFileNotEqualsCanonicalizing()`       |
 | `Assert::assertFileEqualsIgnoringCase()`         | `Assert::assertFileNotEqualsIgnoringCase()`         |
 | `Assert::assertStringEqualsFileCanonicalizing()` | `Assert::assertStringNotEqualsFileCanonicalizing()` |
@@ -389,7 +389,7 @@ COMMENT: No documentation available (yet) for these assertions on the PHPUnit si
 
 Polyfills the following methods:
 |                                   |                                 |
-|-----------------------------------|---------------------------------|
+| --------------------------------- | ------------------------------- |
 | `Assert::equalToCanonicalizing()` | `Assert::equalToIgnoringCase()` |
 | `Assert::equalToWithDelta()`      |                                 |
 
@@ -427,7 +427,7 @@ The original methods these new methods replace were hard deprecated in PHPUnit 9
 
 Polyfills the following methods:
 |                                    |                                       |
-|------------------------------------|---------------------------------------|
+| ---------------------------------- | ------------------------------------- |
 | `Assert::assertIsClosedResource()` | `Assert::assertIsNotClosedResource()` |
 
 These methods were introduced in PHPUnit 9.3.0.
@@ -484,8 +484,8 @@ The `assertObjectEquals()` assertion was introduced in PHPUnit 9.4.0.
 #### PHPUnit < 9.6.11: `Yoast\PHPUnitPolyfills\Polyfills\AssertObjectProperty`
 
 Polyfills the following method:
-|                                       |                                          |
-|---------------------------------------|------------------------------------------|
+|                                     |                                        |
+| ----------------------------------- | -------------------------------------- |
 | `Assert::assertObjectHasProperty()` | `Assert::assertObjectNotHasProperty()` |
 
 These methods were introduced in PHPUnit 10.1.0 as alternatives to the `Assert::assertObjectHasAttribute()` and `Assert::assertObjectNotHasAttribute()` methods, which were hard deprecated (warning) in PHPUnit 9.6.1 and removed in PHPUnit 10.0.0.
@@ -663,7 +663,7 @@ This `TestListenerDefaultImplementation` trait overcomes the signature mismatche
 Similar to the `TestCase` implementation, snake_case methods without type declarations are used to get round the signature mismatches. The snake_case methods will automatically be called.
 
 | PHPUnit native method name | Replacement                             | Notes                                     |
-|----------------------------|-----------------------------------------|-------------------------------------------|
+| -------------------------- | --------------------------------------- | ----------------------------------------- |
 | `addError()`               | `add_error($test, $e, $time)`           |                                           |
 | `addWarning()`             | `add_warning($test, $e, $time)`         | Introduced in PHPUnit 6.                  |
 | `addFailure()`             | `add_failure($test, $e, $time)`         |                                           |
@@ -717,7 +717,7 @@ For frequently used, removed PHPUnit functionality, "helpers" may be provided. T
 #### Removed functionality without PHPUnit native replacement
 
 | PHPUnit | Removed               | Issue          | Remarks                                                                                                                                                                                                                                                                                                                                                                                                                                           |
-|---------|-----------------------|----------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| ------- | --------------------- | -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | 9.0.0   | `assertArraySubset()` | [#1][issue #1] | The [`dms/phpunit-arraysubset-asserts`](https://packagist.org/packages/dms/phpunit-arraysubset-asserts) package polyfills this functionality.<br/>As of [version 0.3.0](https://github.com/rdohms/phpunit-arraysubset-asserts/releases/tag/v0.3.0) this package can be installed in combination with PHP 5.4 - current and PHPUnit 4.8.36/5.7.21 - current.<br/>Alternatively, tests can be refactored using the patterns outlined in [issue #1]. |
 | 9.0.0   | `assertAttribute*()`  | [#2][issue #2] | Refactor the tests to not directly test private/protected properties.<br/>As an interim solution, the [`Yoast\PHPUnitPolyfills\Helpers\AssertAttributeHelper`](#yoastphpunitpolyfillshelpersassertattributehelper) trait is available.                                                                                                                                                                                                            |
 


### PR DESCRIPTION
* Use Node 20 for the Remark check
* Make a tweak to the settings as RemarkLint is being awkward again.
* Fix up the tables to consistently have one space padding.