### PR TITLE
Tests: improve PHP 8.4 deprecation work-around

### DIFF
--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -187,6 +187,7 @@
 	<rule ref="PHPCompatibility.FunctionDeclarations.NewReturnTypeDeclarations">
 		<exclude-pattern>/tests/Polyfills/Fixtures/ChildValueObject\.php$</exclude-pattern>
 		<exclude-pattern>/tests/Polyfills/Fixtures/ValueObject\.php$</exclude-pattern>
+		<exclude-pattern>/tests/Polyfills/Fixtures/ValueObjectParamNotRequired\.php$</exclude-pattern>
 		<exclude-pattern>/tests/Polyfills/Fixtures/ValueObjectUnion\.php$</exclude-pattern>
 	</rule>
 	<rule ref="PHPCompatibility.FunctionDeclarations.NewParamTypeDeclarations.UnionTypeFound">
@@ -194,7 +195,7 @@
 		<exclude-pattern>/tests/Polyfills/Fixtures/ValueObjectUnionNoReturnType\.php$</exclude-pattern>
 	</rule>
 	<rule ref="PHPCompatibility.FunctionDeclarations.NewNullableTypes.typeDeclarationFound">
-		<exclude-pattern>/tests/Polyfills/Fixtures/ValueObject\.php$</exclude-pattern>
+		<exclude-pattern>/tests/Polyfills/Fixtures/ValueObjectParamNotRequired\.php$</exclude-pattern>
 	</rule>
 	<rule ref="PHPCompatibility.Operators.NewOperators.t_spaceshipFound">
 		<exclude-pattern>/tests/Polyfills/Fixtures/ValueObject\.php$</exclude-pattern>

--- a/composer.json
+++ b/composer.json
@@ -61,10 +61,10 @@
 			"@php ./vendor/php-parallel-lint/php-parallel-lint/parallel-lint . -e php --show-deprecated --exclude vendor --exclude .git --exclude src/Exceptions/Error.php --exclude src/Exceptions/TypeError.php --exclude tests/Polyfills/Fixtures/ValueObjectUnion.php --exclude tests/Polyfills/Fixtures/ValueObjectUnionNoReturnType.php"
 		],
 		"lint70": [
-			"@php ./vendor/php-parallel-lint/php-parallel-lint/parallel-lint . -e php --show-deprecated --exclude vendor --exclude .git --exclude src/Exceptions/Error.php --exclude src/Exceptions/TypeError.php --exclude tests/Polyfills/Fixtures/ValueObject.php --exclude tests/Polyfills/Fixtures/ValueObjectUnion.php --exclude tests/Polyfills/Fixtures/ValueObjectUnionNoReturnType.php"
+			"@php ./vendor/php-parallel-lint/php-parallel-lint/parallel-lint . -e php --show-deprecated --exclude vendor --exclude .git --exclude src/Exceptions/Error.php --exclude src/Exceptions/TypeError.php --exclude tests/Polyfills/Fixtures/ValueObjectParamNotRequired.php --exclude tests/Polyfills/Fixtures/ValueObjectUnion.php --exclude tests/Polyfills/Fixtures/ValueObjectUnionNoReturnType.php"
 		],
 		"lint-lt70": [
-			"@php ./vendor/php-parallel-lint/php-parallel-lint/parallel-lint . -e php --show-deprecated --exclude vendor --exclude .git --exclude src/TestCases/TestCasePHPUnitGte8.php --exclude src/TestListeners/TestListenerDefaultImplementationPHPUnitGte7.php --exclude tests/Polyfills/Fixtures/ChildValueObject.php --exclude tests/Polyfills/Fixtures/ValueObject.php --exclude tests/Polyfills/Fixtures/ValueObjectUnion.php --exclude tests/Polyfills/Fixtures/ValueObjectUnionNoReturnType.php"
+			"@php ./vendor/php-parallel-lint/php-parallel-lint/parallel-lint . -e php --show-deprecated --exclude vendor --exclude .git --exclude src/TestCases/TestCasePHPUnitGte8.php --exclude src/TestListeners/TestListenerDefaultImplementationPHPUnitGte7.php --exclude tests/Polyfills/Fixtures/ChildValueObject.php --exclude tests/Polyfills/Fixtures/ValueObject.php --exclude tests/Polyfills/Fixtures/ValueObjectParamNotRequired.php --exclude tests/Polyfills/Fixtures/ValueObjectUnion.php --exclude tests/Polyfills/Fixtures/ValueObjectUnionNoReturnType.php"
 		],
 		"lint-gte80": [
 			"@php ./vendor/php-parallel-lint/php-parallel-lint/parallel-lint . -e php --show-deprecated --exclude vendor --exclude .git"

--- a/tests/Polyfills/AssertObjectEqualsTest.php
+++ b/tests/Polyfills/AssertObjectEqualsTest.php
@@ -10,6 +10,7 @@ use Yoast\PHPUnitPolyfills\Polyfills\ExpectException;
 use Yoast\PHPUnitPolyfills\Polyfills\ExpectExceptionMessageMatches;
 use Yoast\PHPUnitPolyfills\Tests\Polyfills\Fixtures\ChildValueObject;
 use Yoast\PHPUnitPolyfills\Tests\Polyfills\Fixtures\ValueObject;
+use Yoast\PHPUnitPolyfills\Tests\Polyfills\Fixtures\ValueObjectParamNotRequired;
 use Yoast\PHPUnitPolyfills\Tests\Polyfills\Fixtures\ValueObjectUnion;
 
 /**
@@ -18,16 +19,11 @@ use Yoast\PHPUnitPolyfills\Tests\Polyfills\Fixtures\ValueObjectUnion;
  * Due to the use of return types in the classes under test (fixtures), these
  * tests can only run on PHP 7.0 and higher.
  *
- * And due to the implicitly nullable parameter deprecation in PHP 8.4 requiring a
- * nullable type for one of the tests, the minimum PHP version for running this
- * version of the tests has been set to PHP 7.1.
- *
- * The `AssertObjectEqualsPHPUnitLt940Test` class mirrors this test class
- * and tests the polyfill method for PHP < 7.1.
+ * The `AssertObjectEqualsPHPUnitLt940Test` class mirrors this test class.
  *
  * @covers \Yoast\PHPUnitPolyfills\Polyfills\AssertObjectEquals
  *
- * @requires PHP 7.1
+ * @requires PHP 7.0
  */
 final class AssertObjectEqualsTest extends TestCase {
 
@@ -209,10 +205,12 @@ final class AssertObjectEqualsTest extends TestCase {
 	/**
 	 * Verify that the assertObjectEquals() method throws an error when the $method is not a required parameter.
 	 *
+	 * @requires PHP 7.1
+	 *
 	 * @return void
 	 */
 	public function testAssertObjectEqualsFailsOnMethodParamNotRequired() {
-		$msg = 'Comparison method Yoast\PHPUnitPolyfills\Tests\Polyfills\Fixtures\ValueObject::equalsParamNotRequired() does not declare exactly one parameter.';
+		$msg = 'Comparison method Yoast\PHPUnitPolyfills\Tests\Polyfills\Fixtures\ValueObjectParamNotRequired::equalsParamNotRequired() does not declare exactly one parameter.';
 
 		$exception = self::COMPARATOR_EXCEPTION;
 		if ( \class_exists( 'PHPUnit\Framework\ComparisonMethodDoesNotDeclareExactlyOneParameterException' ) ) {
@@ -223,8 +221,8 @@ final class AssertObjectEqualsTest extends TestCase {
 		$this->expectException( $exception );
 		$this->expectExceptionMessage( $msg );
 
-		$expected = new ValueObject( 'test' );
-		$actual   = new ValueObject( 'test' );
+		$expected = new ValueObjectParamNotRequired( 'test' );
+		$actual   = new ValueObjectParamNotRequired( 'test' );
 		$this->assertObjectEquals( $expected, $actual, 'equalsParamNotRequired' );
 	}
 

--- a/tests/Polyfills/Fixtures/ValueObject.php
+++ b/tests/Polyfills/Fixtures/ValueObject.php
@@ -60,17 +60,6 @@ class ValueObject {
 	}
 
 	/**
-	 * Comparator method: incorrectly declared - parameter is not required.
-	 *
-	 * @param self|null $other Object to compare.
-	 *
-	 * @return bool
-	 */
-	public function equalsParamNotRequired( ?self $other = null ): bool {
-		return ( $this->value === $other->value );
-	}
-
-	/**
 	 * Comparator method: incorrectly declared - parameter is not typed.
 	 *
 	 * @param ValueObject $other Object to compare.

--- a/tests/Polyfills/Fixtures/ValueObjectParamNotRequired.php
+++ b/tests/Polyfills/Fixtures/ValueObjectParamNotRequired.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Yoast\PHPUnitPolyfills\Tests\Polyfills\Fixtures;
+
+/**
+ * Fixture to test the AssertObjectEquals trait.
+ *
+ * The `equalsParamNotRequired()` method needs to be in this separate fixture as it needs
+ * a nullable type declaration (PHP 7.1+) to prevent a deprecation about an implicitely nullable
+ * type on PHP 8.4.
+ */
+class ValueObjectParamNotRequired {
+
+	/**
+	 * The value.
+	 *
+	 * @var mixed
+	 */
+	protected $value;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param mixed $value The value.
+	 */
+	public function __construct( $value ) {
+		$this->value = $value;
+	}
+
+	/**
+	 * Comparator method: incorrectly declared - parameter is not required.
+	 *
+	 * @param self|null $other Object to compare.
+	 *
+	 * @return bool
+	 */
+	public function equalsParamNotRequired( ?self $other = null ): bool {
+		return ( $this->value === $other->value );
+	}
+}

--- a/tests/TestCases/TestCaseTestTrait.php
+++ b/tests/TestCases/TestCaseTestTrait.php
@@ -169,7 +169,7 @@ trait TestCaseTestTrait {
 	/**
 	 * Verify availability of trait polyfilled PHPUnit methods [14].
 	 *
-	 * @requires PHP 7.1
+	 * @requires PHP 7.0
 	 *
 	 * @return void
 	 */


### PR DESCRIPTION
Follow-up on PR #159.

This commit builds on the earlier change, but instead of making the whole `AssertObjectEqualsTest` class have a PHP 7.1 minimum requirement, it now limits that requirement to just the one affected test.

The affected test now uses a separate test fixture to allow the bulk of the tests to run on PHP 7.0 (which was the previous minimum requirement for these tests).