### PR TITLE
Docs: minor tweaks

### DIFF
--- a/src/Helpers/ResourceHelper.php
+++ b/src/Helpers/ResourceHelper.php
@@ -114,9 +114,6 @@ final class ResourceHelper {
 	 * Version ranges based on {@link https://3v4l.org/tc4fE}.
 	 * 7.0.8 - 7.0.33, 7.1.0 - 7.1.33, 7.2.0 - 7.2.34, 7.3.0 - 7.3.21, 7.4.0 - 7.4.9
 	 *
-	 * {@internal IMPORTANT: Any changes made to this function should also be made
-	 * to the function in the "empty" version of this trait.}
-	 *
 	 * @return bool
 	 */
 	public static function isIncompatiblePHPForLibXMLResources() {

--- a/src/Polyfills/AssertClosedResource.php
+++ b/src/Polyfills/AssertClosedResource.php
@@ -82,7 +82,7 @@ trait AssertClosedResource {
 	/**
 	 * Helper function to obtain an instance of the Exporter class.
 	 *
-	 * @return SebastianBergmann\Exporter\Exporter|PHPUnitPHAR\SebastianBergmann\Exporter\Exporter|PHPUnit\SebastianBergmann\Exporter\Exporter
+	 * @return Exporter|Exporter_In_Phar|Exporter_In_Phar_Old
 	 */
 	private static function getPHPUnitExporterObject() {
 		if ( \class_exists( 'SebastianBergmann\Exporter\Exporter' ) ) {

--- a/src/Polyfills/AssertFileDirectory.php
+++ b/src/Polyfills/AssertFileDirectory.php
@@ -2,6 +2,7 @@
 
 namespace Yoast\PHPUnitPolyfills\Polyfills;
 
+use PHPUnit_Framework_Exception;
 use PHPUnit_Util_InvalidArgumentHelper;
 
 /**
@@ -25,7 +26,7 @@ trait AssertFileDirectory {
 	 *
 	 * @return void
 	 *
-	 * @throws Exception When the received parameter is not of the expected input type.
+	 * @throws PHPUnit_Framework_Exception When the received parameter is not of the expected input type.
 	 */
 	public static function assertIsReadable( $filename, $message = '' ) {
 		if ( ! \is_string( $filename ) ) {
@@ -48,7 +49,7 @@ trait AssertFileDirectory {
 	 *
 	 * @return void
 	 *
-	 * @throws Exception When the received parameter is not of the expected input type.
+	 * @throws PHPUnit_Framework_Exception When the received parameter is not of the expected input type.
 	 */
 	public static function assertNotIsReadable( $filename, $message = '' ) {
 		if ( ! \is_string( $filename ) ) {
@@ -71,7 +72,7 @@ trait AssertFileDirectory {
 	 *
 	 * @return void
 	 *
-	 * @throws Exception When the received parameter is not of the expected input type.
+	 * @throws PHPUnit_Framework_Exception When the received parameter is not of the expected input type.
 	 */
 	public static function assertIsWritable( $filename, $message = '' ) {
 		if ( ! \is_string( $filename ) ) {
@@ -94,7 +95,7 @@ trait AssertFileDirectory {
 	 *
 	 * @return void
 	 *
-	 * @throws Exception When the received parameter is not of the expected input type.
+	 * @throws PHPUnit_Framework_Exception When the received parameter is not of the expected input type.
 	 */
 	public static function assertNotIsWritable( $filename, $message = '' ) {
 		if ( ! \is_string( $filename ) ) {
@@ -117,7 +118,7 @@ trait AssertFileDirectory {
 	 *
 	 * @return void
 	 *
-	 * @throws Exception When the received parameter is not of the expected input type.
+	 * @throws PHPUnit_Framework_Exception When the received parameter is not of the expected input type.
 	 */
 	public static function assertDirectoryExists( $directory, $message = '' ) {
 		if ( ! \is_string( $directory ) ) {
@@ -140,7 +141,7 @@ trait AssertFileDirectory {
 	 *
 	 * @return void
 	 *
-	 * @throws Exception When the received parameter is not of the expected input type.
+	 * @throws PHPUnit_Framework_Exception When the received parameter is not of the expected input type.
 	 */
 	public static function assertDirectoryNotExists( $directory, $message = '' ) {
 		if ( ! \is_string( $directory ) ) {

--- a/src/Polyfills/EqualToSpecializations.php
+++ b/src/Polyfills/EqualToSpecializations.php
@@ -3,6 +3,7 @@
 namespace Yoast\PHPUnitPolyfills\Polyfills;
 
 use PHPUnit\Framework\Constraint\IsEqual;
+use PHPUnit_Framework_Constraint_IsEqual;
 
 /**
  * Polyfill the Assert::equalToCanonicalizing(), Assert::equalToIgnoringCase() and


### PR DESCRIPTION
* Use unqualified class names in type references in documentation.
* Be specific about the class name.
* Have import `use` statements for all classes, even when only used in the docs.
* Remove outdated comment.