### PR TITLE
CI/QA: add PHPStan

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -14,6 +14,7 @@
 .phpcs.xml.dist         export-ignore
 .remarkignore           export-ignore
 .remarkrc               export-ignore
+phpstan.neon.dist       export-ignore
 phpunit.xml.dist        export-ignore
 
 #

--- a/.github/workflows/cs.yml
+++ b/.github/workflows/cs.yml
@@ -50,3 +50,31 @@ jobs:
       - name: Show PHPCS results in PR
         if: ${{ always() && steps.phpcs.outcome == 'failure' }}
         run: cs2pr ./phpcs-report.xml
+
+  phpstan:
+    name: "PHPStan"
+
+    runs-on: "ubuntu-latest"
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '7.4'
+          coverage: none
+          tools: phpstan
+
+      # Install dependencies and handle caching in one go.
+      # Dependencies need to be installed to make sure the PHPUnit classes are recognized.
+      # @link https://github.com/marketplace/actions/install-php-dependencies-with-composer
+      - name: Install Composer dependencies
+        uses: "ramsey/composer-install@v2"
+        with:
+          # Bust the cache at least once a month - output format: YYYY-MM.
+          custom-cache-suffix: $(date -u "+%Y-%m")
+
+      - name: Run PHPStan
+        run: phpstan analyse

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ vendor/
 /phpunit.xml
 /.phpunit.result.cache
 /build/
+phpstan.neon

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,0 +1,30 @@
+parameters:
+	phpVersion: 70100 # Needs to be 70100 or higher... sigh...
+	level: 9
+	paths:
+		# Explicitly not analyzing the tests for this package as, due to the nature
+		# of this package, it would be too problematic with false positives.
+		- phpunitpolyfills-autoload.php
+		- src
+	excludePaths:
+		# Triggers "Return type mixed of method * is not covariant with return type void of method *" notices, which cannot be ignored.
+		# This exclusion can be removed once PHPUnit 8.0 is the minimum supported version
+		# (and the "drop support for older PHPUnit" task have been executed).
+		- src/TestCases/TestCasePHPUnitLte7.php
+		# Triggers "Referencing prefixed PHPUnit class: PHPUnitPHAR\SebastianBergmann\Exporter\Exporter." notices, which cannot be ignored.
+		- src/Polyfills/AssertClosedResource.php
+
+	ignoreErrors:
+		# Level 5
+		-
+			# False positive, a string callback is perfectly fine, especially for static methods.
+			message: "`^Parameter #1 \\$autoload_function of function spl_autoload_register expects callable\\(string\\): void, 'Yoast…' given\\.$`"
+			count: 1
+			path: phpunitpolyfills-autoload.php
+
+		# Level 9
+		-
+			# This is deliberate and the function call is in a try-catch with error silencing.
+			message: '`^Parameter #1 \$res of function get_resource_type expects resource, mixed given\.$`'
+			count: 1
+			path: src/Helpers/ResourceHelper.php


### PR DESCRIPTION
PHPStan is a good addition to the QA toolkit and with improvements PHPStan has made over the years is now a viable tool for us to use (previously it would give way too many false positives).

This commit:
* Adds a separate job to the `cs` workflow in GH Actions.
    Notes:
    - I've chosen **not** to add PHPStan to the Composer dependencies for two reasons:
        1. It doesn't allow for installation on PHP < 7.2, which would break/block the `composer install` for the test runs.
        2. It would potentially add dependencies which could conflict/cause problems for our test runs due to those defining token constants too.
            _Note: this does not seem to be a problem with the latest versions anymore as the Composer package ships a PHAR file under the hood._
    - We could potentially use [Phive](https://phar.io/) to still have a setup which can be used locally, but just running locally from a PHPStan PHAR file should work just fine.
    - For CI, PHPStan will be installed as a PHAR file by `setup-php` now.
        This does carry a risk _if_ PHPStan would make breaking changes or if a new release adds rules for the levels being scanned as, in that case, builds could unexpectedly start failing.
        The version `setup-php` installs could be hard-coded to the current release `1.11.7`, but that adds an additional maintenance burden of having to keep updating the version as PHPStan releases pretty often.
        So, for now, I've elected to run the risk of random failures. If and when those start happening, we can re-evaluate.
    - The PHP version for the CI run is set to PHP 7.4 to prevent PHPStan throwing some errors/notices related to the outdated PHPUnit version(s) being used.
* Adds a configuration file for PHPStan.
    Notes:
    - The codebase is "clean", so setting scan level to 9 (highest possible).
    - Two files need to be excluded as they contain (non-)issues which PHPStan cannot work around and which prevents those files from being analyzed properly anyway.
* Adds the configuration file to `.gitattributes` and the typical overload file for the configuration file to `.gitignore`.

Refs:
* https://phpstan.org/
* https://phpstan.org/config-reference