### PR TITLE
PHPStan: add bootstrap file

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -15,6 +15,7 @@
 .remarkignore           export-ignore
 .remarkrc               export-ignore
 phpstan.neon.dist       export-ignore
+phpstan-bootstrap.php   export-ignore
 phpunit.xml.dist        export-ignore
 phpunit10.xml.dist      export-ignore
 

--- a/phpstan-bootstrap.php
+++ b/phpstan-bootstrap.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * Bootstrap file for PHPStan.
+ *
+ * @package Yoast\PHPUnitPolyfills
+ *
+ * @phpcs:disable Yoast.NamingConventions.NamespaceName -- This file emulates external classes.
+ * @phpcs:disable Yoast.Commenting.FileComment.Unnecessary -- This is deliberate.
+ * @phpcs:disable Generic.Files.OneObjectStructurePerFile
+ * @phpcs:disable Universal.Namespaces.OneDeclarationPerFile
+ * @phpcs:disable Universal.Namespaces.DisallowCurlyBraceSyntax
+ * @phpcs:disable Squiz.Commenting.FunctionComment.InvalidNoReturn -- These are only stubs, not real functions.
+ */
+
+namespace PHPUnit\SebastianBergmann\Exporter {
+
+	/**
+	 * Emulate the PHPUnit-prefixed Exporter class.
+	 */
+	final class Exporter {
+
+		/**
+		 * Exports a value as a string.
+		 *
+		 * @param mixed $value       The value to export.
+		 * @param int   $indentation The indentation to use.
+		 *
+		 * @return string
+		 */
+		public function export( $value, $indentation = 0 ) {}
+	}
+}
+
+namespace PHPUnitPHAR\SebastianBergmann\Exporter {
+
+	/**
+	 * Emulate the PHPUnitPHAR-prefixed Exporter class.
+	 */
+	final class Exporter {
+
+		/**
+		 * Exports a value as a string.
+		 *
+		 * @param mixed $value       The value to export.
+		 * @param int   $indentation The indentation to use.
+		 *
+		 * @return string
+		 */
+		public function export( $value, $indentation = 0 ) {}
+	}
+}

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,6 +1,8 @@
 parameters:
 	phpVersion: 70100 # Needs to be 70100 or higher... sigh...
 	level: 9
+	bootstrapFiles:
+		- phpstan-bootstrap.php
 	paths:
 		# Explicitly not analyzing the tests for this package as, due to the nature
 		# of this package, it would be too problematic with false positives.
@@ -13,8 +15,22 @@ parameters:
 		- src/TestCases/TestCasePHPUnitLte7.php
 		# Triggers "Referencing prefixed PHPUnit class: PHPUnitPHAR\SebastianBergmann\Exporter\Exporter." notices, which cannot be ignored.
 		- src/Polyfills/AssertClosedResource.php
+		- src/Polyfills/AssertIgnoringLineEndings.php
+	treatPhpDocTypesAsCertain: false
 
 	ignoreErrors:
+		# Level 0
+		# This is part of the functionality of this library. Ignore.
+		-
+			message: '`^Call to an undefined static method Yoast\\PHPUnitPolyfills\\TestCases\\TestCase::assertInternalType\(\)\.$`'
+			count: 1
+			path: src/TestCases/TestCasePHPUnitGte8.php
+
+		-
+			message: '`^Call to an undefined static method Yoast\\PHPUnitPolyfills\\TestCases\\XTestCase::assertInternalType\(\)\.$`'
+			count: 1
+			path: src/TestCases/XTestCase.php
+
 		# Level 5
 		-
 			# False positive, a string callback is perfectly fine, especially for static methods.


### PR DESCRIPTION
Follow up on #175, but now for the 2.x branch.

As this branch uses some uncommon class names which PHPStan does not recognize by default, so tweaks are needed to get a passing build.