### PR TITLE
PHP 8.4 | Silence deprecation notice in the tests

### DIFF
--- a/tests/Polyfills/ExpectPHPExceptionTest.php
+++ b/tests/Polyfills/ExpectPHPExceptionTest.php
@@ -58,6 +58,8 @@ final class ExpectPHPExceptionTest extends TestCase {
 	/**
 	 * Verify availability of the expectError*() methods.
 	 *
+	 * @requires PHP < 9.0
+	 *
 	 * @return void
 	 */
 	public function testErrorCanBeExpected() {
@@ -65,6 +67,14 @@ final class ExpectPHPExceptionTest extends TestCase {
 		$this->expectErrorMessage( 'foo' );
 		$this->expectErrorMessageMatches( '/foo/' );
 
-		\trigger_error( 'foo', \E_USER_ERROR );
+		if ( \PHP_VERSION_ID < 80400 ) {
+			\trigger_error( 'foo', \E_USER_ERROR );
+		}
+		else {
+			// PHP 8.4 deprecates passing `E_USER_ERROR` to `trigger_error()`.
+			// Silence the deprecation notice (but not the error itself).
+			// phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged
+			@\trigger_error( 'foo', \E_USER_ERROR );
+		}
 	}
 }


### PR DESCRIPTION
PHP 8.4 deprecates passing `E_USER_ERROR` to `trigger_error()`, with the recommendation being to replace these type of calls with either an Exception or an `exit` statement.

As this is a test related to the PHPUnit `expectError()` assertion, the basic principle of the test cannot be changed without the test losing its validity.

Instead, this commit silences the PHP 8.4 deprecation notice specifically for PHP 8.4+.

Notes:
* The error silencing can not be added unconditionally as on PHP < 8.0, this would also silence the actual error, not just the deprecation notice.
* The commit also already adds a PHPUnit `@requires` annotation to indicate that the test should be skipped on PHP 9.0 as the deprecation will become an error in PHP 9.0. This `@requires` annotation with an operator is not supported in older PHPUnit version, but that just means the annotation will be ignored and the test will run, which is exactly what is supposed to happen ;-)

Refs:
* https://wiki.php.net/rfc/deprecations_php_8_4#deprecate_passing_e_user_error_to_trigger_error
* https://www.php.net/manual/en/language.operators.errorcontrol.php