### PR TITLE
GH Actions: use "nightly" instead of version nr for PHP-dev

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -20,9 +20,9 @@ jobs:
 
     strategy:
       matrix:
-        php: ['5.4', '5.5', '5.6', '7.0', '7.1', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4']
+        php: ['5.4', '5.5', '5.6', '7.0', '7.1', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3', 'nightly']
 
-    continue-on-error: ${{ matrix.php == '8.4' }}
+    continue-on-error: ${{ matrix.php == 'nightly' }}
 
     name: "Lint: PHP ${{ matrix.php }}"
 
@@ -47,14 +47,14 @@ jobs:
       # Install dependencies and handle caching in one go.
       # @link https://github.com/marketplace/actions/install-php-dependencies-with-composer
       - name: Install Composer dependencies - normal
-        if: matrix.php != '8.4'
+        if: matrix.php != 'nightly'
         uses: "ramsey/composer-install@v3"
         with:
           # Bust the cache at least once a month - output format: YYYY-MM.
           custom-cache-suffix: $(date -u "+%Y-%m")
 
       - name: Install Composer dependencies - ignore PHP restrictions
-        if: matrix.php == '8.4'
+        if: matrix.php == 'nightly'
         uses: "ramsey/composer-install@v3"
         with:
           composer-options: --ignore-platform-req=php+
@@ -62,7 +62,7 @@ jobs:
           custom-cache-suffix: $(date -u "+%Y-%m")
 
       - name: "Lint PHP files against parse errors - PHP < 7.0"
-        if: ${{ matrix.php < 7.0 }}
+        if: ${{ matrix.php != 'nightly' && matrix.php < 7.0 }}
         run: composer lint-lt70
 
       - name: "Lint PHP files against parse errors - PHP 7.0"
@@ -74,9 +74,9 @@ jobs:
         run: composer lint7
 
       - name: "Lint PHP files against parse errors - PHP 8.0 - 8.3"
-        if: ${{ matrix.php >= 8.0 && matrix.php < 8.4 }}
+        if: ${{ matrix.php != 'nightly' && matrix.php >= 8.0 && matrix.php < 8.4 }}
         run: composer lint-gte80
 
       - name: "Lint PHP files against parse errors - PHP >= 8.4"
-        if: ${{ matrix.php >= 8.4 }}
+        if: ${{ matrix.php == 'nightly' || matrix.php >= 8.4 }}
         run: composer lint-gte84

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -84,7 +84,7 @@ jobs:
             experimental: false
 
           # Experimental builds.
-          - php: '8.4'
+          - php: 'nightly'
             phpunit: 'auto' # PHPUnit 9.x.
             coverage: false
             experimental: true
@@ -115,14 +115,14 @@ jobs:
       # Install dependencies and handle caching in one go.
       # @link https://github.com/marketplace/actions/install-php-dependencies-with-composer
       - name: Install Composer dependencies - normal
-        if: matrix.php < '8.3'
+        if: matrix.php != 'nightly'
         uses: "ramsey/composer-install@v3"
         with:
           # Bust the cache at least once a month - output format: YYYY-MM.
           custom-cache-suffix: $(date -u "+%Y-%m")
 
       - name: Install Composer dependencies - ignore PHP restrictions
-        if: matrix.php >= '8.3'
+        if: matrix.php == 'nightly'
         uses: "ramsey/composer-install@v3"
         with:
           composer-options: --ignore-platform-req=php+
@@ -259,12 +259,12 @@ jobs:
             coverage: true
 
           # Experimental builds.
-          - php: '8.4'
+          - php: 'nightly'
             phpunit: '9'
 
     name: "PHAR test: PHP ${{ matrix.php }} - PHPUnit: ${{matrix.phpunit}}"
 
-    continue-on-error: ${{ matrix.php == '8.4' }}
+    continue-on-error: ${{ matrix.php == 'nightly' }}
 
     steps:
       - name: Checkout code
@@ -291,7 +291,7 @@ jobs:
       # Install dependencies and handle caching in one go.
       # @link https://github.com/marketplace/actions/install-php-dependencies-with-composer
       - name: Install Composer dependencies - normal
-        if: matrix.php < '8.3'
+        if: matrix.php != 'nightly'
         uses: "ramsey/composer-install@v3"
         with:
           composer-options: "--no-dev"
@@ -299,7 +299,7 @@ jobs:
           custom-cache-suffix: $(date -u "+%Y-%m")
 
       - name: Install Composer dependencies - ignore PHP restrictions
-        if: matrix.php >= '8.3'
+        if: matrix.php == 'nightly'
         uses: "ramsey/composer-install@v3"
         with:
           composer-options: "--no-dev --ignore-platform-req=php+"


### PR DESCRIPTION
The setup-php action runner offers the `nightly` alias for the PHP "dev" version. By using that alias instead of the hard-coded version number for PHP "next", the manual maintenance needed for the workflows is decreased and made less error-prone.

This also fixes the current "error" that the conditions for the "composer install" step still referenced PHP 8.3 instead of PHP 8.4.

There is a small down-side to this change. To explain this, we need to understand the PHP release cycle.
* Most years, a new PHP version is released towards end of November/beginning of December.
* However, the _branch_ for the new PHP minor/major is cut before the first RC, which - in the current release process - means towards end of September.
* From that moment onward, the "dev" version (`master` branch) of PHP already becomes the "new + 0.1" version.

What this means for the workflows is as follows:
* With a hard-coded "next" PHP version, the tests are run against that exact version until the workflow is manually changed.
* Using "nightly", the tests are run against PHP-next between December - September, but against PHP-next+1 in October and November.

So the practical implications are that the "updating the workflow for the newly released PHP version" task, which is normally executed round the time of the release of a new PHP version, should be moved forward to the time when the first RC of the new PHP version is cut.

As this is a tool used in CI of other projects, officially supporting a new PHP version early, makes sense though, so this "early" update of the workflows for a new PHP version also makes sense.