### PR TITLE
1.x  | Minor updates for start of 3.x branch

### DIFF
--- a/.github/RELEASE-CHECKLIST.md
+++ b/.github/RELEASE-CHECKLIST.md
@@ -1,10 +1,8 @@
-Template to use for release PRs from `#.x` to `main`
+Release checklist
 ===========================================================
 
-Title: Release version x.x.x
-
 <!--
-If both a 1.x and a 2.x release are to be tagged, always tag the 1.x release first!
+If releases for multiple branches are to be tagged, always tag the 1.x release first, 2.x second etc!
 -->
 
 ## Functional
@@ -15,10 +13,10 @@ If both a 1.x and a 2.x release are to be tagged, always tag the 1.x release fir
 ## Release
 - [ ] Add changelog for the release - PR #xxx
     Verify that a release link at the bottom of the `CHANGELOG.md` file has been added.
-- [ ] Merge this PR.
+- [ ] Merge the changelog PR.
 - [ ] Make sure all CI builds are green.
-- [ ] Tag the release (careful, GH defaults to `2.x`!).
-- [ ] Create a release from the tag (careful, GH defaults to `2.x`!) & copy & paste the changelog to it.
+- [ ] Tag the release on the 1.x branch (careful, GH defaults to `3.x`!).
+- [ ] Create a release from the tag (careful, GH defaults to `3.x`!) & copy & paste the changelog to it.
     Make sure to copy the links to the issues and the links to the GH usernames from the bottom of the changelog!
 - [ ] Close the milestone.
 - [ ] Open a new milestone for the next release.

--- a/README.md
+++ b/README.md
@@ -76,14 +76,17 @@ By doing so, dropping support for an older PHPUnit version becomes as straight-f
 
 * Releases in the `1.x` series of the PHPUnit Polyfills support PHPUnit 4.8 - 9.x.
 * Releases in the `2.x` series of the PHPUnit Polyfills support PHPUnit 5.7 - 10.x.
+* Releases in the `3.x` series of the PHPUnit Polyfills support PHPUnit 6.4 - 11.x (but don't support running tests on PHPUnit 10).
 
 Please keep in mind that the PHPUnit Polyfills provide _forward_-compatibility.
-This means that features which PHPUnit no longer supports in PHPUnit 10.x, like expecting PHP deprecation notices or warnings, will not be supported in the PHPUnit Polyfills 2.x series.
+This means that features which PHPUnit no longer supports in PHPUnit 10.x, like expecting PHP deprecation notices or warnings, will not be supported in the PHPUnit Polyfills 2.x series and features not supported in PHPUnit 11.x, will not be supported in the PHPUnit Polyfills 3.x series.
 
-Please refer to the [PHPUnit 10 release notification] and [PHPUnit 10 changelog] to inform your decision on whether or not to upgrade (yet).
+Please refer to the [PHPUnit 10 release notification]/[PHPUnit 10 changelog] and the [PHPUnit 11 release notification]/[PHPUnit 11 changelog] to inform your decision on whether or not to upgrade (yet).
 
 [PHPUnit 10 release notification]: https://phpunit.de/announcements/phpunit-10.html
 [PHPUnit 10 changelog]:            https://github.com/sebastianbergmann/phpunit/blob/10.0.19/ChangeLog-10.0.md
+[PHPUnit 11 release notification]: https://phpunit.de/announcements/phpunit-11.html
+[PHPUnit 11 changelog]:            https://github.com/sebastianbergmann/phpunit/blob/11.0.10/ChangeLog-11.0.md
 
 
 Using this library

--- a/composer.json
+++ b/composer.json
@@ -54,7 +54,7 @@
 	},
 	"extra": {
 		"branch-alias": {
-			"dev-main": "2.x-dev"
+			"dev-main": "3.x-dev"
 		}
 	},
 	"scripts": {


### PR DESCRIPTION
### README: update section about PHPUnit support

The README for the 3.x version will be updated to reflect the features supported in the 3.x series.

This commit updates the README section about which versions of PHPUnit will be supported by which versions of the PHPUnit Polyfills.

### Updates for new 3.x branch

As of now, the `main` branch, will be the release branch for PHPUnit Polyfills 3.x.

Includes minor textual tweaks to the release checklist.