### PR TITLE
2.x | Tests: add attributes for annotations

### DIFF
--- a/src/TestCases/XTestCase.php
+++ b/src/TestCases/XTestCase.php
@@ -2,6 +2,10 @@
 
 namespace Yoast\PHPUnitPolyfills\TestCases;
 
+use PHPUnit\Framework\Attributes\After;
+use PHPUnit\Framework\Attributes\AfterClass;
+use PHPUnit\Framework\Attributes\Before;
+use PHPUnit\Framework\Attributes\BeforeClass;
 use PHPUnit\Framework\TestCase as PHPUnit_TestCase;
 use Yoast\PHPUnitPolyfills\Helpers\AssertAttributeHelper;
 use Yoast\PHPUnitPolyfills\Polyfills\AssertClosedResource;
@@ -55,6 +59,7 @@ abstract class XTestCase extends PHPUnit_TestCase {
 	 *
 	 * @return void
 	 */
+	#[BeforeClass]
 	public static function setUpFixturesBeforeClass() {
 		parent::setUpBeforeClass();
 	}
@@ -68,6 +73,7 @@ abstract class XTestCase extends PHPUnit_TestCase {
 	 *
 	 * @return void
 	 */
+	#[Before]
 	protected function setUpFixtures() {
 		parent::setUp();
 	}
@@ -81,6 +87,7 @@ abstract class XTestCase extends PHPUnit_TestCase {
 	 *
 	 * @return void
 	 */
+	#[After]
 	protected function tearDownFixtures() {
 		parent::tearDown();
 	}
@@ -94,6 +101,7 @@ abstract class XTestCase extends PHPUnit_TestCase {
 	 *
 	 * @return void
 	 */
+	#[AfterClass]
 	public static function tearDownFixturesAfterClass() {
 		parent::tearDownAfterClass();
 	}

--- a/tests/Exceptions/InvalidComparisonMethodExceptionTest.php
+++ b/tests/Exceptions/InvalidComparisonMethodExceptionTest.php
@@ -2,6 +2,7 @@
 
 namespace Yoast\PHPUnitPolyfills\Tests\Exceptions;
 
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Yoast\PHPUnitPolyfills\Exceptions\InvalidComparisonMethodException;
 
@@ -10,6 +11,7 @@ use Yoast\PHPUnitPolyfills\Exceptions\InvalidComparisonMethodException;
  *
  * @covers \Yoast\PHPUnitPolyfills\Exceptions\InvalidComparisonMethodException
  */
+#[CoversClass( InvalidComparisonMethodException::class )]
 final class InvalidComparisonMethodExceptionTest extends TestCase {
 
 	/**

--- a/tests/Helpers/AssertAttributesHelperTest.php
+++ b/tests/Helpers/AssertAttributesHelperTest.php
@@ -2,7 +2,9 @@
 
 namespace Yoast\PHPUnitPolyfills\Tests\Helpers;
 
+use PHPUnit\Framework\Attributes\CoversClass;
 use ReflectionException;
+use Yoast\PHPUnitPolyfills\Helpers\AssertAttributeHelper;
 use Yoast\PHPUnitPolyfills\TestCases\TestCase;
 use Yoast\PHPUnitPolyfills\Tests\Helpers\Fixtures\ClassWithProperties;
 
@@ -11,6 +13,7 @@ use Yoast\PHPUnitPolyfills\Tests\Helpers\Fixtures\ClassWithProperties;
  *
  * @covers \Yoast\PHPUnitPolyfills\Helpers\AssertAttributeHelper
  */
+#[CoversClass( AssertAttributeHelper::class )]
 final class AssertAttributesHelperTest extends TestCase {
 
 	/**

--- a/tests/Polyfills/AssertClosedResourceBzip2Test.php
+++ b/tests/Polyfills/AssertClosedResourceBzip2Test.php
@@ -3,6 +3,7 @@
 namespace Yoast\PHPUnitPolyfills\Tests\Polyfills;
 
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\RequiresPhpExtension;
 use Yoast\PHPUnitPolyfills\Helpers\ResourceHelper;
 use Yoast\PHPUnitPolyfills\Polyfills\AssertClosedResource;
 
@@ -19,6 +20,7 @@ use Yoast\PHPUnitPolyfills\Polyfills\AssertClosedResource;
  */
 #[CoversClass( AssertClosedResource::class )]
 #[CoversClass( ResourceHelper::class )]
+#[RequiresPhpExtension( 'bz2' )]
 final class AssertClosedResourceBzip2Test extends AssertClosedResourceTestCase {
 
 	use AssertClosedResource;

--- a/tests/Polyfills/AssertClosedResourceBzip2Test.php
+++ b/tests/Polyfills/AssertClosedResourceBzip2Test.php
@@ -2,6 +2,8 @@
 
 namespace Yoast\PHPUnitPolyfills\Tests\Polyfills;
 
+use PHPUnit\Framework\Attributes\CoversClass;
+use Yoast\PHPUnitPolyfills\Helpers\ResourceHelper;
 use Yoast\PHPUnitPolyfills\Polyfills\AssertClosedResource;
 
 /**
@@ -15,6 +17,8 @@ use Yoast\PHPUnitPolyfills\Polyfills\AssertClosedResource;
  *
  * @requires extension bz2
  */
+#[CoversClass( AssertClosedResource::class )]
+#[CoversClass( ResourceHelper::class )]
 final class AssertClosedResourceBzip2Test extends AssertClosedResourceTestCase {
 
 	use AssertClosedResource;

--- a/tests/Polyfills/AssertClosedResourceCurlTest.php
+++ b/tests/Polyfills/AssertClosedResourceCurlTest.php
@@ -3,6 +3,8 @@
 namespace Yoast\PHPUnitPolyfills\Tests\Polyfills;
 
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\RequiresPhp;
+use PHPUnit\Framework\Attributes\RequiresPhpExtension;
 use Yoast\PHPUnitPolyfills\Helpers\ResourceHelper;
 use Yoast\PHPUnitPolyfills\Polyfills\AssertClosedResource;
 
@@ -23,6 +25,8 @@ use Yoast\PHPUnitPolyfills\Polyfills\AssertClosedResource;
  */
 #[CoversClass( AssertClosedResource::class )]
 #[CoversClass( ResourceHelper::class )]
+#[RequiresPhp( '< 8.0' )]
+#[RequiresPhpExtension( 'curl' )]
 final class AssertClosedResourceCurlTest extends AssertClosedResourceTestCase {
 
 	use AssertClosedResource;

--- a/tests/Polyfills/AssertClosedResourceCurlTest.php
+++ b/tests/Polyfills/AssertClosedResourceCurlTest.php
@@ -2,6 +2,8 @@
 
 namespace Yoast\PHPUnitPolyfills\Tests\Polyfills;
 
+use PHPUnit\Framework\Attributes\CoversClass;
+use Yoast\PHPUnitPolyfills\Helpers\ResourceHelper;
 use Yoast\PHPUnitPolyfills\Polyfills\AssertClosedResource;
 
 /**
@@ -19,6 +21,8 @@ use Yoast\PHPUnitPolyfills\Polyfills\AssertClosedResource;
  * @requires extension curl
  * @requires PHP < 8.0
  */
+#[CoversClass( AssertClosedResource::class )]
+#[CoversClass( ResourceHelper::class )]
 final class AssertClosedResourceCurlTest extends AssertClosedResourceTestCase {
 
 	use AssertClosedResource;

--- a/tests/Polyfills/AssertClosedResourceDirTest.php
+++ b/tests/Polyfills/AssertClosedResourceDirTest.php
@@ -2,6 +2,8 @@
 
 namespace Yoast\PHPUnitPolyfills\Tests\Polyfills;
 
+use PHPUnit\Framework\Attributes\CoversClass;
+use Yoast\PHPUnitPolyfills\Helpers\ResourceHelper;
 use Yoast\PHPUnitPolyfills\Polyfills\AssertClosedResource;
 
 /**
@@ -13,6 +15,8 @@ use Yoast\PHPUnitPolyfills\Polyfills\AssertClosedResource;
  * @covers \Yoast\PHPUnitPolyfills\Helpers\ResourceHelper
  * @covers \Yoast\PHPUnitPolyfills\Polyfills\AssertClosedResource
  */
+#[CoversClass( AssertClosedResource::class )]
+#[CoversClass( ResourceHelper::class )]
 final class AssertClosedResourceDirTest extends AssertClosedResourceTestCase {
 
 	use AssertClosedResource;

--- a/tests/Polyfills/AssertClosedResourceEnchantTest.php
+++ b/tests/Polyfills/AssertClosedResourceEnchantTest.php
@@ -3,6 +3,8 @@
 namespace Yoast\PHPUnitPolyfills\Tests\Polyfills;
 
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\RequiresPhp;
+use PHPUnit\Framework\Attributes\RequiresPhpExtension;
 use Yoast\PHPUnitPolyfills\Helpers\ResourceHelper;
 use Yoast\PHPUnitPolyfills\Polyfills\AssertClosedResource;
 
@@ -26,6 +28,8 @@ use Yoast\PHPUnitPolyfills\Polyfills\AssertClosedResource;
  */
 #[CoversClass( AssertClosedResource::class )]
 #[CoversClass( ResourceHelper::class )]
+#[RequiresPhp( '< 8.0' )]
+#[RequiresPhpExtension( 'enchant' )]
 final class AssertClosedResourceEnchantTest extends AssertClosedResourceTestCase {
 
 	use AssertClosedResource;

--- a/tests/Polyfills/AssertClosedResourceEnchantTest.php
+++ b/tests/Polyfills/AssertClosedResourceEnchantTest.php
@@ -2,6 +2,8 @@
 
 namespace Yoast\PHPUnitPolyfills\Tests\Polyfills;
 
+use PHPUnit\Framework\Attributes\CoversClass;
+use Yoast\PHPUnitPolyfills\Helpers\ResourceHelper;
 use Yoast\PHPUnitPolyfills\Polyfills\AssertClosedResource;
 
 /**
@@ -22,6 +24,8 @@ use Yoast\PHPUnitPolyfills\Polyfills\AssertClosedResource;
  * @phpcs:disable Generic.PHP.DeprecatedFunctions.Deprecated
  * @phpcs:disable PHPCompatibility.FunctionUse.RemovedFunctions.enchant_broker_freeDeprecated
  */
+#[CoversClass( AssertClosedResource::class )]
+#[CoversClass( ResourceHelper::class )]
 final class AssertClosedResourceEnchantTest extends AssertClosedResourceTestCase {
 
 	use AssertClosedResource;

--- a/tests/Polyfills/AssertClosedResourceFileTest.php
+++ b/tests/Polyfills/AssertClosedResourceFileTest.php
@@ -2,6 +2,8 @@
 
 namespace Yoast\PHPUnitPolyfills\Tests\Polyfills;
 
+use PHPUnit\Framework\Attributes\CoversClass;
+use Yoast\PHPUnitPolyfills\Helpers\ResourceHelper;
 use Yoast\PHPUnitPolyfills\Polyfills\AssertClosedResource;
 
 /**
@@ -13,6 +15,8 @@ use Yoast\PHPUnitPolyfills\Polyfills\AssertClosedResource;
  * @covers \Yoast\PHPUnitPolyfills\Helpers\ResourceHelper
  * @covers \Yoast\PHPUnitPolyfills\Polyfills\AssertClosedResource
  */
+#[CoversClass( AssertClosedResource::class )]
+#[CoversClass( ResourceHelper::class )]
 final class AssertClosedResourceFileTest extends AssertClosedResourceTestCase {
 
 	use AssertClosedResource;

--- a/tests/Polyfills/AssertClosedResourceFinfoTest.php
+++ b/tests/Polyfills/AssertClosedResourceFinfoTest.php
@@ -3,6 +3,8 @@
 namespace Yoast\PHPUnitPolyfills\Tests\Polyfills;
 
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\RequiresPhp;
+use PHPUnit\Framework\Attributes\RequiresPhpExtension;
 use Yoast\PHPUnitPolyfills\Helpers\ResourceHelper;
 use Yoast\PHPUnitPolyfills\Polyfills\AssertClosedResource;
 
@@ -23,6 +25,8 @@ use Yoast\PHPUnitPolyfills\Polyfills\AssertClosedResource;
  */
 #[CoversClass( AssertClosedResource::class )]
 #[CoversClass( ResourceHelper::class )]
+#[RequiresPhp( '< 8.1' )]
+#[RequiresPhpExtension( 'finfo' )]
 final class AssertClosedResourceFinfoTest extends AssertClosedResourceTestCase {
 
 	use AssertClosedResource;

--- a/tests/Polyfills/AssertClosedResourceFinfoTest.php
+++ b/tests/Polyfills/AssertClosedResourceFinfoTest.php
@@ -2,6 +2,8 @@
 
 namespace Yoast\PHPUnitPolyfills\Tests\Polyfills;
 
+use PHPUnit\Framework\Attributes\CoversClass;
+use Yoast\PHPUnitPolyfills\Helpers\ResourceHelper;
 use Yoast\PHPUnitPolyfills\Polyfills\AssertClosedResource;
 
 /**
@@ -19,6 +21,8 @@ use Yoast\PHPUnitPolyfills\Polyfills\AssertClosedResource;
  * @requires extension finfo
  * @requires PHP < 8.1
  */
+#[CoversClass( AssertClosedResource::class )]
+#[CoversClass( ResourceHelper::class )]
 final class AssertClosedResourceFinfoTest extends AssertClosedResourceTestCase {
 
 	use AssertClosedResource;

--- a/tests/Polyfills/AssertClosedResourceGdTest.php
+++ b/tests/Polyfills/AssertClosedResourceGdTest.php
@@ -2,6 +2,8 @@
 
 namespace Yoast\PHPUnitPolyfills\Tests\Polyfills;
 
+use PHPUnit\Framework\Attributes\CoversClass;
+use Yoast\PHPUnitPolyfills\Helpers\ResourceHelper;
 use Yoast\PHPUnitPolyfills\Polyfills\AssertClosedResource;
 
 /**
@@ -19,6 +21,8 @@ use Yoast\PHPUnitPolyfills\Polyfills\AssertClosedResource;
  * @requires extension gd
  * @requires PHP < 8.0
  */
+#[CoversClass( AssertClosedResource::class )]
+#[CoversClass( ResourceHelper::class )]
 final class AssertClosedResourceGdTest extends AssertClosedResourceTestCase {
 
 	use AssertClosedResource;

--- a/tests/Polyfills/AssertClosedResourceGdTest.php
+++ b/tests/Polyfills/AssertClosedResourceGdTest.php
@@ -3,6 +3,8 @@
 namespace Yoast\PHPUnitPolyfills\Tests\Polyfills;
 
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\RequiresPhp;
+use PHPUnit\Framework\Attributes\RequiresPhpExtension;
 use Yoast\PHPUnitPolyfills\Helpers\ResourceHelper;
 use Yoast\PHPUnitPolyfills\Polyfills\AssertClosedResource;
 
@@ -23,6 +25,8 @@ use Yoast\PHPUnitPolyfills\Polyfills\AssertClosedResource;
  */
 #[CoversClass( AssertClosedResource::class )]
 #[CoversClass( ResourceHelper::class )]
+#[RequiresPhp( '< 8.0' )]
+#[RequiresPhpExtension( 'gd' )]
 final class AssertClosedResourceGdTest extends AssertClosedResourceTestCase {
 
 	use AssertClosedResource;

--- a/tests/Polyfills/AssertClosedResourceNotResourceTest.php
+++ b/tests/Polyfills/AssertClosedResourceNotResourceTest.php
@@ -3,9 +3,11 @@
 namespace Yoast\PHPUnitPolyfills\Tests\Polyfills;
 
 use PHPUnit\Framework\AssertionFailedError;
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use PHPUnit_Framework_AssertionFailedError;
 use stdClass;
+use Yoast\PHPUnitPolyfills\Helpers\ResourceHelper;
 use Yoast\PHPUnitPolyfills\Polyfills\AssertClosedResource;
 use Yoast\PHPUnitPolyfills\Polyfills\ExpectExceptionMessageMatches;
 
@@ -15,6 +17,8 @@ use Yoast\PHPUnitPolyfills\Polyfills\ExpectExceptionMessageMatches;
  * @covers \Yoast\PHPUnitPolyfills\Helpers\ResourceHelper
  * @covers \Yoast\PHPUnitPolyfills\Polyfills\AssertClosedResource
  */
+#[CoversClass( AssertClosedResource::class )]
+#[CoversClass( ResourceHelper::class )]
 final class AssertClosedResourceNotResourceTest extends TestCase {
 
 	use AssertClosedResource;

--- a/tests/Polyfills/AssertClosedResourceNotResourceTest.php
+++ b/tests/Polyfills/AssertClosedResourceNotResourceTest.php
@@ -4,6 +4,7 @@ namespace Yoast\PHPUnitPolyfills\Tests\Polyfills;
 
 use PHPUnit\Framework\AssertionFailedError;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use PHPUnit_Framework_AssertionFailedError;
 use stdClass;
@@ -34,6 +35,7 @@ final class AssertClosedResourceNotResourceTest extends TestCase {
 	 *
 	 * @return void
 	 */
+	#[DataProvider( 'dataNotResource' )]
 	public function testAssertIsClosedResource( $value ) {
 		$pattern = '`^Failed asserting that .+? is of type ["]?resource \(closed\)["]?`s';
 
@@ -68,6 +70,7 @@ final class AssertClosedResourceNotResourceTest extends TestCase {
 	 *
 	 * @return void
 	 */
+	#[DataProvider( 'dataNotResource' )]
 	public function testAssertIsNotClosedResource( $value ) {
 		self::assertIsNotClosedResource( $value );
 	}
@@ -99,6 +102,7 @@ final class AssertClosedResourceNotResourceTest extends TestCase {
 	 *
 	 * @return void
 	 */
+	#[DataProvider( 'dataNotResource' )]
 	public function testShouldClosedResourceAssertionBeSkipped( $value ) {
 		$this->assertFalse( self::shouldClosedResourceAssertionBeSkipped( $value ) );
 	}

--- a/tests/Polyfills/AssertClosedResourceProcessTest.php
+++ b/tests/Polyfills/AssertClosedResourceProcessTest.php
@@ -2,6 +2,8 @@
 
 namespace Yoast\PHPUnitPolyfills\Tests\Polyfills;
 
+use PHPUnit\Framework\Attributes\CoversClass;
+use Yoast\PHPUnitPolyfills\Helpers\ResourceHelper;
 use Yoast\PHPUnitPolyfills\Polyfills\AssertClosedResource;
 
 /**
@@ -13,6 +15,8 @@ use Yoast\PHPUnitPolyfills\Polyfills\AssertClosedResource;
  * @covers \Yoast\PHPUnitPolyfills\Helpers\ResourceHelper
  * @covers \Yoast\PHPUnitPolyfills\Polyfills\AssertClosedResource
  */
+#[CoversClass( AssertClosedResource::class )]
+#[CoversClass( ResourceHelper::class )]
 final class AssertClosedResourceProcessTest extends AssertClosedResourceTestCase {
 
 	use AssertClosedResource;

--- a/tests/Polyfills/AssertClosedResourceShmopTest.php
+++ b/tests/Polyfills/AssertClosedResourceShmopTest.php
@@ -3,6 +3,7 @@
 namespace Yoast\PHPUnitPolyfills\Tests\Polyfills;
 
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\RequiresPhpExtension;
 use Yoast\PHPUnitPolyfills\Helpers\ResourceHelper;
 use Yoast\PHPUnitPolyfills\Polyfills\AssertClosedResource;
 
@@ -28,6 +29,7 @@ use Yoast\PHPUnitPolyfills\Polyfills\AssertClosedResource;
  */
 #[CoversClass( AssertClosedResource::class )]
 #[CoversClass( ResourceHelper::class )]
+#[RequiresPhpExtension( 'shmop' )]
 final class AssertClosedResourceShmopTest extends AssertClosedResourceTestCase {
 
 	use AssertClosedResource;

--- a/tests/Polyfills/AssertClosedResourceShmopTest.php
+++ b/tests/Polyfills/AssertClosedResourceShmopTest.php
@@ -2,6 +2,8 @@
 
 namespace Yoast\PHPUnitPolyfills\Tests\Polyfills;
 
+use PHPUnit\Framework\Attributes\CoversClass;
+use Yoast\PHPUnitPolyfills\Helpers\ResourceHelper;
 use Yoast\PHPUnitPolyfills\Polyfills\AssertClosedResource;
 
 /**
@@ -24,6 +26,8 @@ use Yoast\PHPUnitPolyfills\Polyfills\AssertClosedResource;
  * @phpcs:disable Generic.PHP.DeprecatedFunctions.Deprecated
  * @phpcs:disable PHPCompatibility.FunctionUse.RemovedFunctions.shmop_closeDeprecated
  */
+#[CoversClass( AssertClosedResource::class )]
+#[CoversClass( ResourceHelper::class )]
 final class AssertClosedResourceShmopTest extends AssertClosedResourceTestCase {
 
 	use AssertClosedResource;

--- a/tests/Polyfills/AssertClosedResourceShmopTest.php
+++ b/tests/Polyfills/AssertClosedResourceShmopTest.php
@@ -2,6 +2,7 @@
 
 namespace Yoast\PHPUnitPolyfills\Tests\Polyfills;
 
+use PHPUnit\Framework\Attributes\Before;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\RequiresPhpExtension;
 use Yoast\PHPUnitPolyfills\Helpers\ResourceHelper;
@@ -44,6 +45,7 @@ final class AssertClosedResourceShmopTest extends AssertClosedResourceTestCase {
 	 *
 	 * @return void
 	 */
+	#[Before]
 	protected function skipOnIncompatiblePHP() {
 		if ( \PHP_VERSION_ID < 70000 || \PHP_VERSION_ID >= 80000 ) {
 			$this->markTestSkipped( 'This test requires PHP 7.x.' );

--- a/tests/Polyfills/AssertClosedResourceWddxTest.php
+++ b/tests/Polyfills/AssertClosedResourceWddxTest.php
@@ -3,6 +3,8 @@
 namespace Yoast\PHPUnitPolyfills\Tests\Polyfills;
 
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\RequiresPhp;
+use PHPUnit\Framework\Attributes\RequiresPhpExtension;
 use Yoast\PHPUnitPolyfills\Helpers\ResourceHelper;
 use Yoast\PHPUnitPolyfills\Polyfills\AssertClosedResource;
 
@@ -26,6 +28,8 @@ use Yoast\PHPUnitPolyfills\Polyfills\AssertClosedResource;
  */
 #[CoversClass( AssertClosedResource::class )]
 #[CoversClass( ResourceHelper::class )]
+#[RequiresPhp( '< 7.4' )]
+#[RequiresPhpExtension( 'wddx' )]
 final class AssertClosedResourceWddxTest extends AssertClosedResourceTestCase {
 
 	use AssertClosedResource;

--- a/tests/Polyfills/AssertClosedResourceWddxTest.php
+++ b/tests/Polyfills/AssertClosedResourceWddxTest.php
@@ -2,6 +2,8 @@
 
 namespace Yoast\PHPUnitPolyfills\Tests\Polyfills;
 
+use PHPUnit\Framework\Attributes\CoversClass;
+use Yoast\PHPUnitPolyfills\Helpers\ResourceHelper;
 use Yoast\PHPUnitPolyfills\Polyfills\AssertClosedResource;
 
 /**
@@ -22,6 +24,8 @@ use Yoast\PHPUnitPolyfills\Polyfills\AssertClosedResource;
  * @phpcs:disable PHPCompatibility.FunctionUse.RemovedFunctions.wddx_packet_startRemoved
  * @phpcs:disable PHPCompatibility.FunctionUse.RemovedFunctions.wddx_packet_endRemoved
  */
+#[CoversClass( AssertClosedResource::class )]
+#[CoversClass( ResourceHelper::class )]
 final class AssertClosedResourceWddxTest extends AssertClosedResourceTestCase {
 
 	use AssertClosedResource;

--- a/tests/Polyfills/AssertClosedResourceXmlParserTest.php
+++ b/tests/Polyfills/AssertClosedResourceXmlParserTest.php
@@ -2,6 +2,7 @@
 
 namespace Yoast\PHPUnitPolyfills\Tests\Polyfills;
 
+use PHPUnit\Framework\Attributes\CoversClass;
 use Yoast\PHPUnitPolyfills\Helpers\ResourceHelper;
 use Yoast\PHPUnitPolyfills\Polyfills\AssertClosedResource;
 
@@ -20,6 +21,8 @@ use Yoast\PHPUnitPolyfills\Polyfills\AssertClosedResource;
  * @requires extension libxml
  * @requires PHP < 8.0
  */
+#[CoversClass( AssertClosedResource::class )]
+#[CoversClass( ResourceHelper::class )]
 final class AssertClosedResourceXmlParserTest extends AssertClosedResourceTestCase {
 
 	use AssertClosedResource;

--- a/tests/Polyfills/AssertClosedResourceXmlParserTest.php
+++ b/tests/Polyfills/AssertClosedResourceXmlParserTest.php
@@ -3,6 +3,8 @@
 namespace Yoast\PHPUnitPolyfills\Tests\Polyfills;
 
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\RequiresPhp;
+use PHPUnit\Framework\Attributes\RequiresPhpExtension;
 use Yoast\PHPUnitPolyfills\Helpers\ResourceHelper;
 use Yoast\PHPUnitPolyfills\Polyfills\AssertClosedResource;
 
@@ -23,6 +25,8 @@ use Yoast\PHPUnitPolyfills\Polyfills\AssertClosedResource;
  */
 #[CoversClass( AssertClosedResource::class )]
 #[CoversClass( ResourceHelper::class )]
+#[RequiresPhp( '< 8.0' )]
+#[RequiresPhpExtension( 'libxml' )]
 final class AssertClosedResourceXmlParserTest extends AssertClosedResourceTestCase {
 
 	use AssertClosedResource;

--- a/tests/Polyfills/AssertClosedResourceZipTest.php
+++ b/tests/Polyfills/AssertClosedResourceZipTest.php
@@ -2,6 +2,8 @@
 
 namespace Yoast\PHPUnitPolyfills\Tests\Polyfills;
 
+use PHPUnit\Framework\Attributes\CoversClass;
+use Yoast\PHPUnitPolyfills\Helpers\ResourceHelper;
 use Yoast\PHPUnitPolyfills\Polyfills\AssertClosedResource;
 
 /**
@@ -23,6 +25,8 @@ use Yoast\PHPUnitPolyfills\Polyfills\AssertClosedResource;
  * @phpcs:disable PHPCompatibility.FunctionUse.RemovedFunctions.zip_closeDeprecated
  * @phpcs:disable WordPress.PHP.NoSilencedErrors.Discouraged
  */
+#[CoversClass( AssertClosedResource::class )]
+#[CoversClass( ResourceHelper::class )]
 final class AssertClosedResourceZipTest extends AssertClosedResourceTestCase {
 
 	use AssertClosedResource;

--- a/tests/Polyfills/AssertClosedResourceZipTest.php
+++ b/tests/Polyfills/AssertClosedResourceZipTest.php
@@ -3,6 +3,7 @@
 namespace Yoast\PHPUnitPolyfills\Tests\Polyfills;
 
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\RequiresPhpExtension;
 use Yoast\PHPUnitPolyfills\Helpers\ResourceHelper;
 use Yoast\PHPUnitPolyfills\Polyfills\AssertClosedResource;
 
@@ -27,6 +28,7 @@ use Yoast\PHPUnitPolyfills\Polyfills\AssertClosedResource;
  */
 #[CoversClass( AssertClosedResource::class )]
 #[CoversClass( ResourceHelper::class )]
+#[RequiresPhpExtension( 'zip' )]
 final class AssertClosedResourceZipTest extends AssertClosedResourceTestCase {
 
 	use AssertClosedResource;

--- a/tests/Polyfills/AssertClosedResourceZlibTest.php
+++ b/tests/Polyfills/AssertClosedResourceZlibTest.php
@@ -2,6 +2,8 @@
 
 namespace Yoast\PHPUnitPolyfills\Tests\Polyfills;
 
+use PHPUnit\Framework\Attributes\CoversClass;
+use Yoast\PHPUnitPolyfills\Helpers\ResourceHelper;
 use Yoast\PHPUnitPolyfills\Polyfills\AssertClosedResource;
 
 /**
@@ -15,6 +17,8 @@ use Yoast\PHPUnitPolyfills\Polyfills\AssertClosedResource;
  *
  * @requires extension zlib
  */
+#[CoversClass( AssertClosedResource::class )]
+#[CoversClass( ResourceHelper::class )]
 final class AssertClosedResourceZlibTest extends AssertClosedResourceTestCase {
 
 	use AssertClosedResource;

--- a/tests/Polyfills/AssertClosedResourceZlibTest.php
+++ b/tests/Polyfills/AssertClosedResourceZlibTest.php
@@ -3,6 +3,7 @@
 namespace Yoast\PHPUnitPolyfills\Tests\Polyfills;
 
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\RequiresPhpExtension;
 use Yoast\PHPUnitPolyfills\Helpers\ResourceHelper;
 use Yoast\PHPUnitPolyfills\Polyfills\AssertClosedResource;
 
@@ -19,6 +20,7 @@ use Yoast\PHPUnitPolyfills\Polyfills\AssertClosedResource;
  */
 #[CoversClass( AssertClosedResource::class )]
 #[CoversClass( ResourceHelper::class )]
+#[RequiresPhpExtension( 'zlib' )]
 final class AssertClosedResourceZlibTest extends AssertClosedResourceTestCase {
 
 	use AssertClosedResource;

--- a/tests/Polyfills/AssertEqualsSpecializationsTest.php
+++ b/tests/Polyfills/AssertEqualsSpecializationsTest.php
@@ -2,6 +2,7 @@
 
 namespace Yoast\PHPUnitPolyfills\Tests\Polyfills;
 
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Yoast\PHPUnitPolyfills\Polyfills\AssertEqualsSpecializations;
 
@@ -10,6 +11,7 @@ use Yoast\PHPUnitPolyfills\Polyfills\AssertEqualsSpecializations;
  *
  * @covers \Yoast\PHPUnitPolyfills\Polyfills\AssertEqualsSpecializations
  */
+#[CoversClass( AssertEqualsSpecializations::class )]
 final class AssertEqualsSpecializationsTest extends TestCase {
 
 	use AssertEqualsSpecializations;

--- a/tests/Polyfills/AssertFileEqualsSpecializationsTest.php
+++ b/tests/Polyfills/AssertFileEqualsSpecializationsTest.php
@@ -2,6 +2,7 @@
 
 namespace Yoast\PHPUnitPolyfills\Tests\Polyfills;
 
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Yoast\PHPUnitPolyfills\Polyfills\AssertFileEqualsSpecializations;
 
@@ -10,6 +11,7 @@ use Yoast\PHPUnitPolyfills\Polyfills\AssertFileEqualsSpecializations;
  *
  * @covers \Yoast\PHPUnitPolyfills\Polyfills\AssertFileEqualsSpecializations
  */
+#[CoversClass( AssertFileEqualsSpecializations::class )]
 final class AssertFileEqualsSpecializationsTest extends TestCase {
 
 	use AssertFileEqualsSpecializations;

--- a/tests/Polyfills/AssertIgnoringLineEndingsTest.php
+++ b/tests/Polyfills/AssertIgnoringLineEndingsTest.php
@@ -3,6 +3,7 @@
 namespace Yoast\PHPUnitPolyfills\Tests\Polyfills;
 
 use PHPUnit\Framework\AssertionFailedError;
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use PHPUnit\Runner\Version as PHPUnit_Version;
 use PHPUnit\SebastianBergmann\Exporter\Exporter as Exporter_In_Phar_Old;
@@ -20,6 +21,7 @@ use Yoast\PHPUnitPolyfills\Polyfills\ExpectExceptionMessageMatches;
  *
  * @covers \Yoast\PHPUnitPolyfills\Polyfills\AssertIgnoringLineEndings
  */
+#[CoversClass( AssertIgnoringLineEndings::class )]
 final class AssertIgnoringLineEndingsTest extends TestCase {
 
 	use AssertIgnoringLineEndings;

--- a/tests/Polyfills/AssertIgnoringLineEndingsTest.php
+++ b/tests/Polyfills/AssertIgnoringLineEndingsTest.php
@@ -4,6 +4,7 @@ namespace Yoast\PHPUnitPolyfills\Tests\Polyfills;
 
 use PHPUnit\Framework\AssertionFailedError;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use PHPUnit\Runner\Version as PHPUnit_Version;
 use PHPUnit\SebastianBergmann\Exporter\Exporter as Exporter_In_Phar_Old;
@@ -38,6 +39,7 @@ final class AssertIgnoringLineEndingsTest extends TestCase {
 	 *
 	 * @return void
 	 */
+	#[DataProvider( 'dataThrowsTypeErrorOnInvalidType' )]
 	public function testAssertStringEqualsStringIgnoringLineEndingsThrowsTypeErrorOnInvalidTypeArg1( $input ) {
 		if ( \PHP_VERSION_ID >= 80100
 			&& \version_compare( PHPUnit_Version::id(), '10.0.0', '>=' )
@@ -65,6 +67,7 @@ final class AssertIgnoringLineEndingsTest extends TestCase {
 	 *
 	 * @return void
 	 */
+	#[DataProvider( 'dataThrowsTypeErrorOnInvalidType' )]
 	public function testAssertStringEqualsStringIgnoringLineEndingsThrowsTypeErrorOnInvalidTypeArg2( $input ) {
 		if ( \PHP_VERSION_ID >= 80100
 			&& \version_compare( PHPUnit_Version::id(), '10.0.0', '>=' )
@@ -93,6 +96,8 @@ final class AssertIgnoringLineEndingsTest extends TestCase {
 	 *
 	 * @return void
 	 */
+	#[DataProvider( 'dataAllLineEndingVariations' )]
+	#[DataProvider( 'dataAssertStringEqualsStringIgnoringLineEndingsTypeVariations' )]
 	public function testAssertStringEqualsStringIgnoringLineEndings( $expected, $actual ) {
 		self::assertStringEqualsStringIgnoringLineEndings( $expected, $actual );
 	}
@@ -141,6 +146,7 @@ final class AssertIgnoringLineEndingsTest extends TestCase {
 	 *
 	 * @return void
 	 */
+	#[DataProvider( 'dataAssertStringEqualsStringIgnoringLineEndingsFails' )]
 	public function testAssertStringEqualsStringIgnoringLineEndingsFails( $expected, $actual ) {
 
 		$exporter = self::getPHPUnitExporterObjectForIgnoringLineEndingsForTests();
@@ -207,6 +213,7 @@ final class AssertIgnoringLineEndingsTest extends TestCase {
 	 *
 	 * @return void
 	 */
+	#[DataProvider( 'dataThrowsTypeErrorOnInvalidType' )]
 	public function testAssertStringContainsStringIgnoringLineEndingsThrowsTypeErrorOnInvalidTypeArg1( $input ) {
 		if ( \PHP_VERSION_ID >= 80100
 			&& \version_compare( PHPUnit_Version::id(), '10.0.0', '>=' )
@@ -234,6 +241,7 @@ final class AssertIgnoringLineEndingsTest extends TestCase {
 	 *
 	 * @return void
 	 */
+	#[DataProvider( 'dataThrowsTypeErrorOnInvalidType' )]
 	public function testAssertStringContainsStringIgnoringLineEndingsThrowsTypeErrorOnInvalidTypeArg2( $input ) {
 		if ( \PHP_VERSION_ID >= 80100
 			&& \version_compare( PHPUnit_Version::id(), '10.0.0', '>=' )
@@ -261,6 +269,7 @@ final class AssertIgnoringLineEndingsTest extends TestCase {
 	 *
 	 * @return void
 	 */
+	#[DataProvider( 'dataAssertStringContainsStringIgnoringLineEndings' )]
 	public function testAssertStringContainsStringIgnoringLineEndings( $needle, $haystack ) {
 		$this->assertStringContainsStringIgnoringLineEndings( $needle, $haystack );
 	}
@@ -296,6 +305,7 @@ final class AssertIgnoringLineEndingsTest extends TestCase {
 	 *
 	 * @return void
 	 */
+	#[DataProvider( 'dataAllLineEndingVariations' )]
 	public function testAssertStringContainsStringIgnoringLineEndingsBug5279( $needle, $haystack ) {
 		if ( \version_compare( PHPUnit_Version::id(), '10.0.0', '>=' )
 			&& \version_compare( PHPUnit_Version::id(), '10.0.16', '<' )
@@ -318,6 +328,7 @@ final class AssertIgnoringLineEndingsTest extends TestCase {
 	 *
 	 * @return void
 	 */
+	#[DataProvider( 'dataAssertStringContainsStringIgnoringLineEndingsFails' )]
 	public function testAssertStringContainsStringIgnoringLineEndingsFails( $needle, $haystack ) {
 		$exporter = self::getPHPUnitExporterObjectForIgnoringLineEndingsForTests();
 		$pattern  = \sprintf(

--- a/tests/Polyfills/AssertIsListTest.php
+++ b/tests/Polyfills/AssertIsListTest.php
@@ -4,6 +4,7 @@ namespace Yoast\PHPUnitPolyfills\Tests\Polyfills;
 
 use PHPUnit\Framework\AssertionFailedError;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use PHPUnit_Framework_AssertionFailedError;
 use stdClass;
@@ -31,6 +32,7 @@ final class AssertIsListTest extends TestCase {
 	 *
 	 * @return void
 	 */
+	#[DataProvider( 'dataAssertIsListFailsOnInvalidInputType' )]
 	public function testAssertIsListFailsOnInvalidInputType( $actual, $type ) {
 		$this->expectException( $this->getAssertionFailedExceptionName() );
 		$this->expectExceptionMessageMatches( '`^Failed asserting that ' . $type . ' is a list`' );
@@ -89,6 +91,7 @@ final class AssertIsListTest extends TestCase {
 	 *
 	 * @return void
 	 */
+	#[DataProvider( 'dataAssertIsListPass' )]
 	public function testAssertIsListPass( $actual ) {
 		$this->assertIsList( $actual );
 	}
@@ -128,6 +131,7 @@ final class AssertIsListTest extends TestCase {
 	 *
 	 * @return void
 	 */
+	#[DataProvider( 'dataAssertIsListFail' )]
 	public function testAssertIsListFail( $actual ) {
 		$this->expectException( $this->getAssertionFailedExceptionName() );
 		$this->expectExceptionMessage( 'Failed asserting that an array is a list' );

--- a/tests/Polyfills/AssertIsListTest.php
+++ b/tests/Polyfills/AssertIsListTest.php
@@ -3,6 +3,7 @@
 namespace Yoast\PHPUnitPolyfills\Tests\Polyfills;
 
 use PHPUnit\Framework\AssertionFailedError;
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use PHPUnit_Framework_AssertionFailedError;
 use stdClass;
@@ -14,6 +15,7 @@ use Yoast\PHPUnitPolyfills\Polyfills\ExpectExceptionMessageMatches;
  *
  * @covers \Yoast\PHPUnitPolyfills\Polyfills\AssertIsList
  */
+#[CoversClass( AssertIsList::class )]
 final class AssertIsListTest extends TestCase {
 
 	use AssertIsList;

--- a/tests/Polyfills/AssertIsTypeTest.php
+++ b/tests/Polyfills/AssertIsTypeTest.php
@@ -2,6 +2,7 @@
 
 namespace Yoast\PHPUnitPolyfills\Tests\Polyfills;
 
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use stdClass;
 use Yoast\PHPUnitPolyfills\Polyfills\AssertIsType;
@@ -11,6 +12,7 @@ use Yoast\PHPUnitPolyfills\Polyfills\AssertIsType;
  *
  * @covers \Yoast\PHPUnitPolyfills\Polyfills\AssertIsType
  */
+#[CoversClass( AssertIsType::class )]
 final class AssertIsTypeTest extends TestCase {
 
 	use AssertIsType;

--- a/tests/Polyfills/AssertObjectEqualsPHPUnitLt940Test.php
+++ b/tests/Polyfills/AssertObjectEqualsPHPUnitLt940Test.php
@@ -3,6 +3,7 @@
 namespace Yoast\PHPUnitPolyfills\Tests\Polyfills;
 
 use PHPUnit\Framework\AssertionFailedError;
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use PHPUnit\Runner\Version as PHPUnit_Version;
 use PHPUnit_Framework_AssertionFailedError;
@@ -30,6 +31,7 @@ use Yoast\PHPUnitPolyfills\Tests\Polyfills\Fixtures\ValueObjectUnionNoReturnType
  *
  * @covers \Yoast\PHPUnitPolyfills\Polyfills\AssertObjectEquals
  */
+#[CoversClass( AssertObjectEquals::class )]
 final class AssertObjectEqualsPHPUnitLt940Test extends TestCase {
 
 	use AssertObjectEquals;

--- a/tests/Polyfills/AssertObjectEqualsPHPUnitLt940Test.php
+++ b/tests/Polyfills/AssertObjectEqualsPHPUnitLt940Test.php
@@ -4,6 +4,7 @@ namespace Yoast\PHPUnitPolyfills\Tests\Polyfills;
 
 use PHPUnit\Framework\AssertionFailedError;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\RequiresPhp;
 use PHPUnit\Framework\TestCase;
 use PHPUnit\Runner\Version as PHPUnit_Version;
 use PHPUnit_Framework_AssertionFailedError;
@@ -209,6 +210,7 @@ final class AssertObjectEqualsPHPUnitLt940Test extends TestCase {
 	 *
 	 * @return void
 	 */
+	#[RequiresPhp( '8.0' )]
 	public function testAssertObjectEqualsFailsOnMethodParamHasUnionTypeDeclaration() {
 		$msg = 'Parameter of comparison method Yoast\PHPUnitPolyfills\Tests\Polyfills\Fixtures\ValueObjectUnionNoReturnType::equalsParamUnionType() does not have a declared type.';
 

--- a/tests/Polyfills/AssertObjectEqualsPHPUnitLt940Test.php
+++ b/tests/Polyfills/AssertObjectEqualsPHPUnitLt940Test.php
@@ -3,6 +3,7 @@
 namespace Yoast\PHPUnitPolyfills\Tests\Polyfills;
 
 use PHPUnit\Framework\AssertionFailedError;
+use PHPUnit\Framework\Attributes\Before;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\RequiresPhp;
 use PHPUnit\Framework\TestCase;
@@ -57,6 +58,7 @@ final class AssertObjectEqualsPHPUnitLt940Test extends TestCase {
 	 *
 	 * @return void
 	 */
+	#[Before]
 	public function maybeSkipTest() {
 		if ( \version_compare( PHPUnit_Version::id(), '9.4.0', '>=' ) ) {
 			$this->markTestSkipped( 'This test can not be run with the PHPUnit native implementation of assertObjectEquals()' );

--- a/tests/Polyfills/AssertObjectEqualsTest.php
+++ b/tests/Polyfills/AssertObjectEqualsTest.php
@@ -4,6 +4,7 @@ namespace Yoast\PHPUnitPolyfills\Tests\Polyfills;
 
 use PHPUnit\Framework\AssertionFailedError;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\RequiresPhp;
 use PHPUnit\Framework\ComparisonMethodDoesNotAcceptParameterTypeException;
 use PHPUnit\Framework\ComparisonMethodDoesNotDeclareBoolReturnTypeException;
 use PHPUnit\Framework\ComparisonMethodDoesNotDeclareExactlyOneParameterException;
@@ -35,6 +36,7 @@ use Yoast\PHPUnitPolyfills\Tests\Polyfills\Fixtures\ValueObjectUnion;
  * @requires PHP 7.0
  */
 #[CoversClass( AssertObjectEquals::class )]
+#[RequiresPhp( '7.0' )]
 final class AssertObjectEqualsTest extends TestCase {
 
 	use AssertObjectEquals;
@@ -218,6 +220,7 @@ final class AssertObjectEqualsTest extends TestCase {
 	 *
 	 * @return void
 	 */
+	#[RequiresPhp( '7.1' )]
 	public function testAssertObjectEqualsFailsOnMethodParamNotRequired() {
 		$msg = 'Comparison method Yoast\PHPUnitPolyfills\Tests\Polyfills\Fixtures\ValueObjectParamNotRequired::equalsParamNotRequired() does not declare exactly one parameter.';
 
@@ -266,6 +269,7 @@ final class AssertObjectEqualsTest extends TestCase {
 	 *
 	 * @return void
 	 */
+	#[RequiresPhp( '8.0' )]
 	public function testAssertObjectEqualsFailsOnMethodParamHasUnionTypeDeclaration() {
 		$msg = 'Parameter of comparison method Yoast\PHPUnitPolyfills\Tests\Polyfills\Fixtures\ValueObjectUnion::equalsParamUnionType() does not have a declared type.';
 

--- a/tests/Polyfills/AssertObjectEqualsTest.php
+++ b/tests/Polyfills/AssertObjectEqualsTest.php
@@ -3,6 +3,7 @@
 namespace Yoast\PHPUnitPolyfills\Tests\Polyfills;
 
 use PHPUnit\Framework\AssertionFailedError;
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\ComparisonMethodDoesNotAcceptParameterTypeException;
 use PHPUnit\Framework\ComparisonMethodDoesNotDeclareBoolReturnTypeException;
 use PHPUnit\Framework\ComparisonMethodDoesNotDeclareExactlyOneParameterException;
@@ -33,6 +34,7 @@ use Yoast\PHPUnitPolyfills\Tests\Polyfills\Fixtures\ValueObjectUnion;
  *
  * @requires PHP 7.0
  */
+#[CoversClass( AssertObjectEquals::class )]
 final class AssertObjectEqualsTest extends TestCase {
 
 	use AssertObjectEquals;

--- a/tests/Polyfills/AssertObjectPropertyTest.php
+++ b/tests/Polyfills/AssertObjectPropertyTest.php
@@ -4,6 +4,7 @@ namespace Yoast\PHPUnitPolyfills\Tests\Polyfills;
 
 use PHPUnit\Framework\AssertionFailedError;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use PHPUnit\Runner\Version as PHPUnit_Version;
 use PHPUnit_Framework_AssertionFailedError;
@@ -47,6 +48,7 @@ final class AssertObjectPropertyTest extends TestCase {
 	 *
 	 * @return void
 	 */
+	#[DataProvider( 'dataAssertObjectPropertyFailsOnInvalidInputTypePropertyName' )]
 	public function testAssertObjectHasPropertyFailsOnInvalidInputTypePropertyName( $input ) {
 		if ( \is_scalar( $input ) && $this->usesNativePHPUnitAssertion() ) {
 			$this->markTestSkipped( 'PHPUnit native implementation relies on strict_types and when not used will accept scalar inputs' );
@@ -76,6 +78,7 @@ final class AssertObjectPropertyTest extends TestCase {
 	 *
 	 * @return void
 	 */
+	#[DataProvider( 'dataAssertObjectPropertyFailsOnInvalidInputTypePropertyName' )]
 	public function testAssertObjectNotHasPropertyFailsOnInvalidInputTypePropertyName( $input ) {
 		if ( \is_scalar( $input ) && $this->usesNativePHPUnitAssertion() ) {
 			$this->markTestSkipped( 'PHPUnit native implementation relies on strict_types and when not used will accept scalar inputs' );
@@ -126,6 +129,7 @@ final class AssertObjectPropertyTest extends TestCase {
 	 *
 	 * @return void
 	 */
+	#[DataProvider( 'dataAssertObjectPropertyFailsOnInvalidInputTypeObject' )]
 	public function testAssertObjectHasPropertyFailsOnInvalidInputTypeObject( $input ) {
 		$this->expectException( TypeError::class );
 
@@ -151,6 +155,7 @@ final class AssertObjectPropertyTest extends TestCase {
 	 *
 	 * @return void
 	 */
+	#[DataProvider( 'dataAssertObjectPropertyFailsOnInvalidInputTypeObject' )]
 	public function testAssertObjectNotHasPropertyFailsOnInvalidInputTypeObject( $input ) {
 		$this->expectException( TypeError::class );
 
@@ -197,6 +202,7 @@ final class AssertObjectPropertyTest extends TestCase {
 	 *
 	 * @return void
 	 */
+	#[DataProvider( 'dataAssertObjectPropertyDeclaredProps' )]
 	public function testAssertObjectHasPropertyPass( $name ) {
 		$this->assertObjectHasProperty( $name, new ObjectWithProperties() );
 	}
@@ -210,6 +216,7 @@ final class AssertObjectPropertyTest extends TestCase {
 	 *
 	 * @return void
 	 */
+	#[DataProvider( 'dataAssertObjectPropertyUnavailableProps' )]
 	public function testAssertObjectNotHasPropertyPass( $name ) {
 		self::assertObjectNotHasProperty( $name, new ObjectWithProperties() );
 	}
@@ -223,6 +230,7 @@ final class AssertObjectPropertyTest extends TestCase {
 	 *
 	 * @return void
 	 */
+	#[DataProvider( 'dataAssertObjectPropertyUnavailableProps' )]
 	public function testAssertObjectHasPropertyFails( $name ) {
 		$pattern = \sprintf(
 			'`^Failed asserting that object of class "[^\s]*ObjectWithProperties" has (?:property|attribute) "%s"\.`',
@@ -244,6 +252,7 @@ final class AssertObjectPropertyTest extends TestCase {
 	 *
 	 * @return void
 	 */
+	#[DataProvider( 'dataAssertObjectPropertyDeclaredProps' )]
 	public function testAssertObjectNotHasPropertyFails( $name ) {
 		$pattern = \sprintf(
 			'`^Failed asserting that object of class "[^\s]*ObjectWithProperties" does not have (?:property|attribute) "%s"\.`',

--- a/tests/Polyfills/AssertObjectPropertyTest.php
+++ b/tests/Polyfills/AssertObjectPropertyTest.php
@@ -3,6 +3,7 @@
 namespace Yoast\PHPUnitPolyfills\Tests\Polyfills;
 
 use PHPUnit\Framework\AssertionFailedError;
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use PHPUnit\Runner\Version as PHPUnit_Version;
 use PHPUnit_Framework_AssertionFailedError;
@@ -19,6 +20,7 @@ use Yoast\PHPUnitPolyfills\Tests\Polyfills\Fixtures\ObjectWithProperties;
  *
  * @covers \Yoast\PHPUnitPolyfills\Polyfills\AssertObjectProperty
  */
+#[CoversClass( AssertObjectProperty::class )]
 final class AssertObjectPropertyTest extends TestCase {
 
 	use AssertObjectProperty;

--- a/tests/Polyfills/AssertStringContainsTest.php
+++ b/tests/Polyfills/AssertStringContainsTest.php
@@ -3,6 +3,7 @@
 namespace Yoast\PHPUnitPolyfills\Tests\Polyfills;
 
 use PHPUnit\Framework\AssertionFailedError;
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use PHPUnit_Framework_AssertionFailedError;
 use Yoast\PHPUnitPolyfills\Polyfills\AssertStringContains;
@@ -13,6 +14,7 @@ use Yoast\PHPUnitPolyfills\Polyfills\ExpectExceptionMessageMatches;
  *
  * @covers \Yoast\PHPUnitPolyfills\Polyfills\AssertStringContains
  */
+#[CoversClass( AssertStringContains::class )]
 final class AssertStringContainsTest extends TestCase {
 
 	use AssertStringContains;

--- a/tests/Polyfills/AssertStringContainsTest.php
+++ b/tests/Polyfills/AssertStringContainsTest.php
@@ -4,6 +4,7 @@ namespace Yoast\PHPUnitPolyfills\Tests\Polyfills;
 
 use PHPUnit\Framework\AssertionFailedError;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use PHPUnit_Framework_AssertionFailedError;
 use Yoast\PHPUnitPolyfills\Polyfills\AssertStringContains;
@@ -71,6 +72,7 @@ final class AssertStringContainsTest extends TestCase {
 	 *
 	 * @return void
 	 */
+	#[DataProvider( 'dataHaystacks' )]
 	public function testAssertStringContainsStringEmptyNeedle( $haystack ) {
 		$this->assertStringContainsString( '', $haystack );
 	}
@@ -105,6 +107,7 @@ final class AssertStringContainsTest extends TestCase {
 	 *
 	 * @return void
 	 */
+	#[DataProvider( 'dataHaystacks' )]
 	public function testAssertStringNotContainsStringEmptyNeedle( $haystack ) {
 		$pattern = "`^Failed asserting that '{$haystack}'( \[[^\]]+\]\(length: [0-9]+\))? does not contain \"\"( \[[^\]]+\]\(length: [0-9]+\))?\.`";
 

--- a/tests/Polyfills/AssertionRenamesTest.php
+++ b/tests/Polyfills/AssertionRenamesTest.php
@@ -2,6 +2,7 @@
 
 namespace Yoast\PHPUnitPolyfills\Tests\Polyfills;
 
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Yoast\PHPUnitPolyfills\Polyfills\AssertionRenames;
 use Yoast\PHPUnitPolyfills\Polyfills\AssertIsType;
@@ -11,6 +12,7 @@ use Yoast\PHPUnitPolyfills\Polyfills\AssertIsType;
  *
  * @covers \Yoast\PHPUnitPolyfills\Polyfills\AssertionRenames
  */
+#[CoversClass( AssertionRenames::class )]
 final class AssertionRenamesTest extends TestCase {
 
 	use AssertionRenames;

--- a/tests/Polyfills/EqualToSpecializationsTest.php
+++ b/tests/Polyfills/EqualToSpecializationsTest.php
@@ -2,6 +2,7 @@
 
 namespace Yoast\PHPUnitPolyfills\Tests\Polyfills;
 
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Yoast\PHPUnitPolyfills\Polyfills\EqualToSpecializations;
 
@@ -10,6 +11,7 @@ use Yoast\PHPUnitPolyfills\Polyfills\EqualToSpecializations;
  *
  * @covers \Yoast\PHPUnitPolyfills\Polyfills\EqualToSpecializations
  */
+#[CoversClass( EqualToSpecializations::class )]
 final class EqualToSpecializationsTest extends TestCase {
 
 	use EqualToSpecializations;

--- a/tests/Polyfills/ExpectExceptionMessageMatchesTest.php
+++ b/tests/Polyfills/ExpectExceptionMessageMatchesTest.php
@@ -3,6 +3,7 @@
 namespace Yoast\PHPUnitPolyfills\Tests\Polyfills;
 
 use Exception;
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Yoast\PHPUnitPolyfills\Polyfills\ExpectExceptionMessageMatches;
 
@@ -11,6 +12,7 @@ use Yoast\PHPUnitPolyfills\Polyfills\ExpectExceptionMessageMatches;
  *
  * @covers \Yoast\PHPUnitPolyfills\Polyfills\ExpectExceptionMessageMatches
  */
+#[CoversClass( ExpectExceptionMessageMatches::class )]
 final class ExpectExceptionMessageMatchesTest extends TestCase {
 
 	use ExpectExceptionMessageMatches;

--- a/tests/Polyfills/ExpectExceptionObjectTest.php
+++ b/tests/Polyfills/ExpectExceptionObjectTest.php
@@ -3,6 +3,7 @@
 namespace Yoast\PHPUnitPolyfills\Tests\Polyfills;
 
 use Exception;
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Yoast\PHPUnitPolyfills\Polyfills\ExpectExceptionObject;
 
@@ -11,6 +12,7 @@ use Yoast\PHPUnitPolyfills\Polyfills\ExpectExceptionObject;
  *
  * @covers \Yoast\PHPUnitPolyfills\Polyfills\ExpectExceptionObject
  */
+#[CoversClass( ExpectExceptionObject::class )]
 final class ExpectExceptionObjectTest extends TestCase {
 
 	use ExpectExceptionObject;

--- a/tests/TestCases/TestCaseTest.php
+++ b/tests/TestCases/TestCaseTest.php
@@ -2,6 +2,7 @@
 
 namespace Yoast\PHPUnitPolyfills\Tests\TestCases;
 
+use PHPUnit\Framework\Attributes\CoversClass;
 use Yoast\PHPUnitPolyfills\TestCases\TestCase;
 
 /**
@@ -9,6 +10,7 @@ use Yoast\PHPUnitPolyfills\TestCases\TestCase;
  *
  * @covers \Yoast\PHPUnitPolyfills\TestCases\TestCase
  */
+#[CoversClass( TestCase::class )]
 final class TestCaseTest extends TestCase {
 
 	use TestCaseTestTrait;

--- a/tests/TestCases/TestCaseTest.php
+++ b/tests/TestCases/TestCaseTest.php
@@ -3,6 +3,7 @@
 namespace Yoast\PHPUnitPolyfills\Tests\TestCases;
 
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Yoast\PHPUnitPolyfills\TestCases\TestCase;
 
 /**
@@ -129,6 +130,7 @@ final class TestCaseTest extends TestCase {
 	 *
 	 * @return void
 	 */
+	#[DataProvider( 'dataHaveFixtureMethodsBeenTriggered' )]
 	public function testHaveFixtureMethodsBeenTriggered(
 		$expectedBeforeClass,
 		$expectedBefore,

--- a/tests/TestCases/TestCaseTestTrait.php
+++ b/tests/TestCases/TestCaseTestTrait.php
@@ -3,6 +3,7 @@
 namespace Yoast\PHPUnitPolyfills\Tests\TestCases;
 
 use Exception;
+use PHPUnit\Framework\Attributes\RequiresPhp;
 use stdClass;
 use Yoast\PHPUnitPolyfills\Tests\Polyfills\AssertFileEqualsSpecializationsTest;
 use Yoast\PHPUnitPolyfills\Tests\Polyfills\Fixtures\ValueObject;
@@ -129,6 +130,7 @@ trait TestCaseTestTrait {
 	 *
 	 * @return void
 	 */
+	#[RequiresPhp( '7.0' )]
 	final public function testAvailabilityAssertObjectEquals() {
 		$expected = new ValueObject( 'test' );
 		$actual   = new ValueObject( 'test' );

--- a/tests/TestCases/XTestCaseTest.php
+++ b/tests/TestCases/XTestCaseTest.php
@@ -2,6 +2,10 @@
 
 namespace Yoast\PHPUnitPolyfills\Tests\TestCases;
 
+use PHPUnit\Framework\Attributes\After;
+use PHPUnit\Framework\Attributes\AfterClass;
+use PHPUnit\Framework\Attributes\Before;
+use PHPUnit\Framework\Attributes\BeforeClass;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use Yoast\PHPUnitPolyfills\TestCases\XTestCase;
@@ -47,6 +51,7 @@ final class XTestCaseTest extends XTestCase {
 	 *
 	 * @return void
 	 */
+	#[BeforeClass]
 	public static function setUpFixturesBeforeClass() {
 		parent::setUpFixturesBeforeClass();
 
@@ -60,6 +65,7 @@ final class XTestCaseTest extends XTestCase {
 	 *
 	 * @return void
 	 */
+	#[Before]
 	protected function setUpFixtures() {
 		parent::setUpFixtures();
 
@@ -73,6 +79,7 @@ final class XTestCaseTest extends XTestCase {
 	 *
 	 * @return void
 	 */
+	#[After]
 	protected function tearDownFixtures() {
 		++self::$after;
 
@@ -86,6 +93,7 @@ final class XTestCaseTest extends XTestCase {
 	 *
 	 * @return void
 	 */
+	#[AfterClass]
 	public static function tearDownFixturesAfterClass() {
 		// Reset.
 		self::$beforeClass = 0;

--- a/tests/TestCases/XTestCaseTest.php
+++ b/tests/TestCases/XTestCaseTest.php
@@ -3,6 +3,7 @@
 namespace Yoast\PHPUnitPolyfills\Tests\TestCases;
 
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Yoast\PHPUnitPolyfills\TestCases\XTestCase;
 
 /**
@@ -107,6 +108,7 @@ final class XTestCaseTest extends XTestCase {
 	 *
 	 * @return void
 	 */
+	#[DataProvider( 'dataHaveFixtureMethodsBeenTriggered' )]
 	public function testHaveFixtureMethodsBeenTriggered( $expectedBeforeClass, $expectedBefore, $expectedAfter ) {
 		$this->assertSame(
 			$expectedBeforeClass,

--- a/tests/TestCases/XTestCaseTest.php
+++ b/tests/TestCases/XTestCaseTest.php
@@ -2,6 +2,7 @@
 
 namespace Yoast\PHPUnitPolyfills\Tests\TestCases;
 
+use PHPUnit\Framework\Attributes\CoversClass;
 use Yoast\PHPUnitPolyfills\TestCases\XTestCase;
 
 /**
@@ -9,6 +10,7 @@ use Yoast\PHPUnitPolyfills\TestCases\XTestCase;
  *
  * @covers \Yoast\PHPUnitPolyfills\TestCases\XTestCase
  */
+#[CoversClass( XTestCase::class )]
 final class XTestCaseTest extends XTestCase {
 
 	use TestCaseTestTrait;

--- a/tests/TestListeners/Fixtures/FailurePHPUnitGte7.php
+++ b/tests/TestListeners/Fixtures/FailurePHPUnitGte7.php
@@ -2,6 +2,7 @@
 
 namespace Yoast\PHPUnitPolyfills\Tests\TestListeners\Fixtures;
 
+use PHPUnit\Framework\Attributes\RequiresPhpunit;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -9,6 +10,7 @@ use PHPUnit\Framework\TestCase;
  *
  * @requires PHPUnit 7.0
  */
+#[RequiresPhpunit( '7.0' )]
 class FailurePHPUnitGte7 extends TestCase {
 
 	/**

--- a/tests/TestListeners/Fixtures/IncompletePHPUnitGte7.php
+++ b/tests/TestListeners/Fixtures/IncompletePHPUnitGte7.php
@@ -2,6 +2,7 @@
 
 namespace Yoast\PHPUnitPolyfills\Tests\TestListeners\Fixtures;
 
+use PHPUnit\Framework\Attributes\RequiresPhpunit;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -9,6 +10,7 @@ use PHPUnit\Framework\TestCase;
  *
  * @requires PHPUnit 7.0
  */
+#[RequiresPhpunit( '7.0' )]
 class IncompletePHPUnitGte7 extends TestCase {
 
 	/**

--- a/tests/TestListeners/Fixtures/RiskyPHPUnitGte7.php
+++ b/tests/TestListeners/Fixtures/RiskyPHPUnitGte7.php
@@ -2,6 +2,7 @@
 
 namespace Yoast\PHPUnitPolyfills\Tests\TestListeners\Fixtures;
 
+use PHPUnit\Framework\Attributes\RequiresPhpunit;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -9,6 +10,7 @@ use PHPUnit\Framework\TestCase;
  *
  * @requires PHPUnit 7.0
  */
+#[RequiresPhpunit( '7.0' )]
 class RiskyPHPUnitGte7 extends TestCase {
 
 	/**

--- a/tests/TestListeners/Fixtures/SkippedPHPUnitGte7.php
+++ b/tests/TestListeners/Fixtures/SkippedPHPUnitGte7.php
@@ -2,6 +2,7 @@
 
 namespace Yoast\PHPUnitPolyfills\Tests\TestListeners\Fixtures;
 
+use PHPUnit\Framework\Attributes\RequiresPhpunit;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -9,6 +10,7 @@ use PHPUnit\Framework\TestCase;
  *
  * @requires PHPUnit 7.0
  */
+#[RequiresPhpunit( '7.0' )]
 class SkippedPHPUnitGte7 extends TestCase {
 
 	/**

--- a/tests/TestListeners/Fixtures/SuccessPHPUnitGte7.php
+++ b/tests/TestListeners/Fixtures/SuccessPHPUnitGte7.php
@@ -2,6 +2,7 @@
 
 namespace Yoast\PHPUnitPolyfills\Tests\TestListeners\Fixtures;
 
+use PHPUnit\Framework\Attributes\RequiresPhpunit;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -9,6 +10,7 @@ use PHPUnit\Framework\TestCase;
  *
  * @requires PHPUnit 7.0
  */
+#[RequiresPhpunit( '7.0' )]
 class SuccessPHPUnitGte7 extends TestCase {
 
 	/**

--- a/tests/TestListeners/Fixtures/TestErrorPHPUnitGte7.php
+++ b/tests/TestListeners/Fixtures/TestErrorPHPUnitGte7.php
@@ -14,6 +14,7 @@ use PHPUnit\Framework\TestCase;
  * @coversNothing
  */
 #[CoversNothing]
+#[RequiresPhpunit( '7.0' )]
 class TestErrorPHPUnitGte7 extends TestCase {
 
 	/**

--- a/tests/TestListeners/Fixtures/TestErrorPHPUnitGte7.php
+++ b/tests/TestListeners/Fixtures/TestErrorPHPUnitGte7.php
@@ -3,6 +3,7 @@
 namespace Yoast\PHPUnitPolyfills\Tests\TestListeners\Fixtures;
 
 use Exception;
+use PHPUnit\Framework\Attributes\CoversNothing;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -12,6 +13,7 @@ use PHPUnit\Framework\TestCase;
  *
  * @coversNothing
  */
+#[CoversNothing]
 class TestErrorPHPUnitGte7 extends TestCase {
 
 	/**

--- a/tests/TestListeners/Fixtures/WarningPHPUnitGte7.php
+++ b/tests/TestListeners/Fixtures/WarningPHPUnitGte7.php
@@ -2,6 +2,7 @@
 
 namespace Yoast\PHPUnitPolyfills\Tests\TestListeners\Fixtures;
 
+use PHPUnit\Framework\Attributes\RequiresPhpunit;
 use PHPUnit\Framework\TestCase;
 use PHPUnit\Framework\Warning as PHPUnit_Warning;
 
@@ -10,6 +11,7 @@ use PHPUnit\Framework\Warning as PHPUnit_Warning;
  *
  * @requires PHPUnit 7.0
  */
+#[RequiresPhpunit( '7.0' )]
 class WarningPHPUnitGte7 extends TestCase {
 
 	/**

--- a/tests/TestListeners/TestListenerTest.php
+++ b/tests/TestListeners/TestListenerTest.php
@@ -3,6 +3,7 @@
 namespace Yoast\PHPUnitPolyfills\Tests\TestListeners;
 
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\RequiresPhpunit;
 use PHPUnit\Framework\TestCase as PHPUnitTestCase;
 use PHPUnit\Framework\TestResult;
 use Yoast\PHPUnitPolyfills\Autoload;
@@ -21,6 +22,7 @@ use Yoast\PHPUnitPolyfills\Tests\TestListeners\Fixtures\TestListenerImplementati
  */
 #[CoversClass( TestListenerDefaultImplementation::class )]
 #[CoversClass( TestListenerSnakeCaseMethods::class )]
+#[RequiresPhpunit( '< 10' )]
 final class TestListenerTest extends TestCase {
 
 	/**
@@ -73,6 +75,7 @@ final class TestListenerTest extends TestCase {
 	 *
 	 * @return void
 	 */
+	#[RequiresPhpunit( '5' )]
 	public function testWarning() {
 		$test = $this->getTestObject( 'Warning' );
 		$test->run( $this->result );
@@ -119,6 +122,7 @@ final class TestListenerTest extends TestCase {
 	 *
 	 * @return void
 	 */
+	#[RequiresPhpunit( '6' )]
 	public function testRisky() {
 		$test = $this->getTestObject( 'Risky' );
 		$test->run( $this->result );

--- a/tests/TestListeners/TestListenerTest.php
+++ b/tests/TestListeners/TestListenerTest.php
@@ -2,10 +2,13 @@
 
 namespace Yoast\PHPUnitPolyfills\Tests\TestListeners;
 
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase as PHPUnitTestCase;
 use PHPUnit\Framework\TestResult;
 use Yoast\PHPUnitPolyfills\Autoload;
 use Yoast\PHPUnitPolyfills\TestCases\TestCase;
+use Yoast\PHPUnitPolyfills\TestListeners\TestListenerDefaultImplementation;
+use Yoast\PHPUnitPolyfills\TestListeners\TestListenerSnakeCaseMethods;
 use Yoast\PHPUnitPolyfills\Tests\TestListeners\Fixtures\TestListenerImplementation;
 
 /**
@@ -16,6 +19,8 @@ use Yoast\PHPUnitPolyfills\Tests\TestListeners\Fixtures\TestListenerImplementati
  *
  * @requires PHPUnit < 10
  */
+#[CoversClass( TestListenerDefaultImplementation::class )]
+#[CoversClass( TestListenerSnakeCaseMethods::class )]
 final class TestListenerTest extends TestCase {
 
 	/**


### PR DESCRIPTION
PHPUnit 10 introduced attributes as replacements for docblock annotations.
PHPUnit 11 deprecates the use of docblock annotations in favour of attributes.

If both an attribute as well as an annotation are found, no PHPUnit deprecation warning will be thrown.

However, between PHPUnit 10.0 and PHPUnit 11.3.2, if the `failOnDeprecation` is set to `true` (which it is for this library as the builds should fail on deprecations in PHP), builds will _also_ fail on deprecation notices from PHPUnit itself.

This behaviour was (finally) changed in PHPUnit 10.5.32 and 11.3.3 (released this week), but that's insufficient for our needs.
For this library running the tests on high/low PHPUnit on each PHP version is imperative. It is also not the job of this library to decide the target PHPUnit versions for the consumer projects, so we cannot raise the minimum PHPUnit 11 version to 11.3.3.

This means that without the attributes, the test runs for the package would fail on PHPUnit 11.0.0 - 11.3.2.

As these attributes are already available in PHPUnit 10, it makes sense then to add them for both the 2.x branch, as well as the (upcoming) 3.x branch.

Note: due to the syntax for attributes, these can be safely added as they are ignored as comments on PHP < 8.0.
Along the same line, if there is no "listener" for the attributes (PHP 8.0/PHPUnit 9.x), they are ignored by PHP as well.


### Tests: add Covers* attributes

This commit adds the `Covers*` attributes in all the appropriate places.

The `@covers` annotations remain as code coverage also still needs to be measure on PHP 5.6 - 8.0 using PHPUnit 5.x - 9.x.
These can be removed once the codebase has a PHP 8.1/PHPUnit 10 minimum requirement.

## Tests: add DataProvider attributes

This commit adds the `DataProvider` attributes in all the appropriate places.

The `@dataProvider` annotations remain as the tests also still need to run on  PHP 5.6 - 8.0 using PHPUnit 5.x - 9.x.
These can be removed once the codebase has a PHP 8.1/PHPUnit 10 minimum requirement.


### Tests: add Requires* attributes

This commit adds the `Requires*` attributes in all the appropriate places.

The `@requires` annotations remain as the tests also still need to run on PHP 5.6 - 8.0 using PHPUnit 5.x - 9.x.
These can be removed once the codebase has a PHP 8.1/PHPUnit 10 minimum requirement.

### Tests: add Before/After[Class] attributes

This commit adds the `Before/After*` attributes in all the appropriate places.

The `@before/after*` annotations remain as the tests also still need to run on PHP 5.6 - 8.0 using PHPUnit 5.x - 9.x.
These can be removed once the codebase has a PHP 8.1/PHPUnit 10 minimum requirement.
