### PR TITLE
PHPUnit 11.3.1 | AssertIsList: sync error message with upstream

### DIFF
--- a/src/Polyfills/AssertIsList.php
+++ b/src/Polyfills/AssertIsList.php
@@ -3,6 +3,7 @@
 namespace Yoast\PHPUnitPolyfills\Polyfills;
 
 use PHPUnit\Framework\Assert;
+use ReflectionObject;
 
 /**
  * Polyfill the Assert::assertIsList() method.
@@ -58,12 +59,32 @@ trait AssertIsList {
 	/**
 	 * Returns the description of the failure.
 	 *
-	 * @param mixed $other The value under test.
+	 * @param mixed $value The value under test.
 	 *
 	 * @return string
 	 */
-	private static function assertIsListFailureDescription( $other ) {
-		$type = \strtolower( \gettype( $other ) );
+	private static function assertIsListFailureDescription( $value ) {
+		$message = 'Failed asserting that %s is a list.';
+
+		if ( \is_object( $value ) ) {
+			// Improved error message as per upstream since PHPUnit 11.3.1.
+			$reflector   = new ReflectionObject( $value );
+			$description = 'an instance of class ' . $reflector->getName();
+
+			if ( $reflector->isAnonymous() ) {
+				$name   = \str_replace( 'class@anonymous', '', $reflector->getName() );
+				$length = \strpos( $name, '$' );
+				if ( \is_int( $length ) ) {
+					$name = \substr( $name, 0, $length );
+				}
+
+				$description = 'an instance of anonymous class created at ' . $name;
+			}
+
+			return \sprintf( $message, $description );
+		}
+
+		$type = \strtolower( \gettype( $value ) );
 
 		switch ( $type ) {
 			case 'double':
@@ -76,7 +97,6 @@ trait AssertIsList {
 
 			case 'array':
 			case 'integer':
-			case 'object':
 				$description = 'an ' . $type;
 				break;
 
@@ -97,6 +117,6 @@ trait AssertIsList {
 				break;
 		}
 
-		return \sprintf( 'Failed asserting that %s is a list.', $description );
+		return \sprintf( $message, $description );
 	}
 }

--- a/tests/Polyfills/AssertIsListTest.php
+++ b/tests/Polyfills/AssertIsListTest.php
@@ -7,6 +7,7 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use stdClass;
+use Yoast\PHPUnitPolyfills\Autoload;
 use Yoast\PHPUnitPolyfills\Polyfills\AssertIsList;
 use Yoast\PHPUnitPolyfills\Polyfills\ExpectExceptionMessageMatches;
 
@@ -49,6 +50,15 @@ final class AssertIsListTest extends TestCase {
 		$resource = \fopen( __DIR__ . '/Fixtures/test.txt', 'r' );
 		\fclose( $resource );
 
+		// The error message for objects was improved in PHPUnit 11.3.1 and this improvement
+		// is emulated in the polyfill for PHPUnit < 10.
+		$improved_error_message = false;
+		if ( \version_compare( Autoload::getPHPUnitVersion(), '10.0.0', '<' )
+			|| \version_compare( Autoload::getPHPUnitVersion(), '11.3.1', '>=' )
+		) {
+			$improved_error_message = true;
+		}
+
 		return [
 			'null' => [
 				'actual' => null,
@@ -70,9 +80,13 @@ final class AssertIsListTest extends TestCase {
 				'actual' => 'text',
 				'type'   => 'a string',
 			],
-			'object' => [
+			'named object' => [
 				'actual' => new stdClass(),
-				'type'   => 'an object',
+				'type'   => ( $improved_error_message === true ) ? 'an instance of class stdClass' : 'an object',
+			],
+			'anonymous object' => [
+				'actual' => new class() {},
+				'type'   => ( $improved_error_message === true ) ? 'an instance of anonymous class created at \S+' : 'an object',
 			],
 			'closed resource' => [
 				'actual' => $resource,


### PR DESCRIPTION
PHPUnit 11.3.1 improved the type information in select assertion failure messages.

For the polyfills, this only affects the `AssertIsList` polyfill.

Now the choice was between the following:
* Just update the test(s) to have a different message expectation for PHPUnit 11.3.1+.
* Update the polyfills to mirror the improvement made in PHPUnit upstream.

I've chosen to implement the latter as it makes the message significantly more informative.

This means that on PHPUnit 6.x to 9.x and 11.3.1+, the new, improved message is shown. While on PHPUnit 10.0 - 11.3.0, the "old" message is shown as, in that case, the PHPUnit native `assertIsList()` method is used without the message improvements.

Includes:
* Renaming the `assertIsListFailureDescription()` method parameter from `$other` to `$value` to be more descriptive.
* Updating the tests, including adding an extra test with an anonymous class as that has separate handling for the error message in the polyfill.

Refs:
* https://github.com/sebastianbergmann/phpunit/commit/5e8b79e52717cf330ce1023ec4b255541812ba70
* https://github.com/sebastianbergmann/phpunit/commit/42cfc7d5982eac708fab2a566021959b31a49aa5