### PR TITLE
PHPUnit 11 | Make select methods `protected`

### DIFF
--- a/src/Polyfills/ExpectExceptionMessageMatches.php
+++ b/src/Polyfills/ExpectExceptionMessageMatches.php
@@ -23,7 +23,7 @@ trait ExpectExceptionMessageMatches {
 	 *
 	 * @return void
 	 */
-	final public function expectExceptionMessageMatches( $regularExpression ) {
+	final protected function expectExceptionMessageMatches( $regularExpression ) {
 		$this->expectExceptionMessageRegExp( $regularExpression );
 	}
 }


### PR DESCRIPTION
PHPUnit 11.0 changed the visibility of a number of `TestCase` methods from `public` to `protected`, so the PHPUnit Polyfills should follow suit.

For the Polyfills, the only affected method is the polyfilled `expectExceptionMessageMatches()` method.

Refs:
* sebastianbergmann/phpunit#5213
* https://github.com/sebastianbergmann/phpunit/commit/8b8e38e962c1aa9b2a2497c00f66dc364f02092d