### PR TITLE
Partially revert "README/Changelog: fix a few URLs which have changed"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-This projects adheres to [Keep a CHANGELOG](https://keepachangelog.com/en/1.1.0/) and uses [Semantic Versioning](https://semver.org/).
+This projects adheres to [Keep a CHANGELOG](http://keepachangelog.com/) and uses [Semantic Versioning](https://semver.org/).
 
 
 ## [Unreleased]

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ PHPUnit Polyfills
 [![CS Build Status](https://github.com/Yoast/PHPUnit-Polyfills/actions/workflows/cs.yml/badge.svg)](https://github.com/Yoast/PHPUnit-Polyfills/actions/workflows/cs.yml)
 [![Lint Build Status](https://github.com/Yoast/PHPUnit-Polyfills/actions/workflows/lint.yml/badge.svg)](https://github.com/Yoast/PHPUnit-Polyfills/actions/workflows/lint.yml)
 [![Test Build Status](https://github.com/Yoast/PHPUnit-Polyfills/actions/workflows/test.yml/badge.svg)](https://github.com/Yoast/PHPUnit-Polyfills/actions/workflows/test.yml)
-[![Coverage Status](https://img.shields.io/coverallsCoverage/github/Yoast/PHPUnit-Polyfills?branch=1.x)](https://coveralls.io/github/Yoast/PHPUnit-Polyfills?branch=1.x)
+[![Coverage Status](https://coveralls.io/repos/github/Yoast/PHPUnit-Polyfills/badge.svg?branch=1.x)](https://coveralls.io/github/Yoast/PHPUnit-Polyfills?branch=1.x)
 
 [![Minimum PHP Version](https://img.shields.io/packagist/dependency-v/yoast/phpunit-polyfills/php.svg)][Packagist]
 [![License: BSD3](https://img.shields.io/github/license/Yoast/PHPUnit-Polyfills)](https://github.com/Yoast/PHPUnit-Polyfills/blob/main/LICENSE)
@@ -474,7 +474,7 @@ if ( self::shouldClosedResourceAssertionBeSkipped( $actual ) === false ) {
 ```
 
 > :point_right: While this polyfill is tested extensively, testing for these kind of bugs _exhaustively_ is _hard_.
-> Please [report any bugs](https://github.com/Yoast/PHPUnit-Polyfills/issues) found and include a clear code sample to reproduce the issue.
+> Please [report any bugs](https://github.com/Yoast/PHPUnit-Polyfills/issues/new/choose) found and include a clear code sample to reproduce the issue.
 
 #### PHPUnit < 9.4.0: `Yoast\PHPUnitPolyfills\Polyfills\AssertObjectEquals`
 


### PR DESCRIPTION
This partially reverts commit 0d2d6105602617d8bccd3b099a2489e254d734d8 (PR #206) after improvements upstream in the Remark no-dead-urls module.

Ref: remarkjs/remark-lint-no-dead-urls#54