### PR TITLE
PHPStan 2.0: update configuration

### DIFF
--- a/.github/workflows/cs.yml
+++ b/.github/workflows/cs.yml
@@ -65,7 +65,7 @@ jobs:
         with:
           php-version: '7.4'
           coverage: none
-          tools: phpstan:1.x
+          tools: phpstan:2.x
 
       # Install dependencies and handle caching in one go.
       # Dependencies need to be installed to make sure the PHPUnit classes are recognized.

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -15,6 +15,21 @@ parameters:
 		- src/Polyfills/AssertClosedResource.php
 
 	ignoreErrors:
+		# Level 4
+		# This is part of the functionality of this package. Safe to ignore.
+		-
+			message: "`^Call to function method_exists\\(\\) with '\\W+PHPUnit\\W+Framework…' and '(assert|expect|equalTo)[^']+' will always evaluate to true\\.$`"
+			count: 15
+			path: phpunitpolyfills-autoload.php
+
+		# The traits are functionality, but not used by the package itself. Can't be helped.
+		-
+			identifier: trait.unused
+			path: src/TestListeners/TestListenerDefaultImplementationPHPUnitLte5.php
+		-
+			identifier: trait.unused
+			path: src/TestListeners/TestListenerSnakeCaseMethods.php
+
 		# Level 5
 		-
 			# False positive, a string callback is perfectly fine, especially for static methods.


### PR DESCRIPTION
PHPStan 2.0 has been released :tada:

This commit updates the PHPStan configuration file for use with PHPStan 2.0 and switches the workflow to start using PHPStan 2.0.

Refs:
* https://phpstan.org/blog/phpstan-2-0-released-level-10-elephpants
* https://github.com/phpstan/phpstan/blob/2.0.x/UPGRADING.md
* https://github.com/phpstan/phpstan/releases/tag/2.0.0