### PR TITLE
Add pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,3 @@
+<!--
+REMINDER: Please target the **oldest** branch of the PHPUnit Polyfills that is affected by this issue.
+-->

--- a/.remarkrc
+++ b/.remarkrc
@@ -19,7 +19,7 @@
     "remark-lint-no-duplicate-definitions",
     "remark-lint-no-empty-url",
     "remark-lint-no-file-name-consecutive-dashes",
-    "remark-lint-no-file-name-irregular-characters",
+    ["remark-lint-no-file-name-irregular-characters", "\\.a-zA-Z0-9-_"],
     "remark-lint-no-file-name-outer-dashes",
     "remark-lint-no-heading-like-paragraph",
     "remark-lint-no-literal-urls",


### PR DESCRIPTION
Mostly as I have a tendency to forget to change the target branch to the oldest supported version for a PR when I haven't worked on this repo for a little while ... oops...

Let's hope this reminder will help prevent such snafus in the future.

Includes a tweak to the Remark config as the file name of the template needs to comply with the requirements by GitHub for such templates and this conflicts with the file name expectations set by Remark (by default).

Ref: https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository