### PR TITLE
Remark: ignore a particular anchor link

### DIFF
--- a/.remarkrc
+++ b/.remarkrc
@@ -12,7 +12,8 @@
         "remark-lint-no-dead-urls",
         {
             "skipUrlPatterns": [
-                "^https?://github\\.com/Yoast/PHPUnit-Polyfills/compare/[0-9\\.]+?\\.{3}[0-9\\.]+"
+                "^https?://github\\.com/Yoast/PHPUnit-Polyfills/compare/[0-9\\.]+?\\.{3}[0-9\\.]+",
+                "https://github.com/Yoast/PHPUnit-Polyfills/issues/186#issuecomment-2334326687"
             ]
         }
     ],


### PR DESCRIPTION
... as Remark seems to be struggling with it and we don't have influence on the potentially broken HTML created by GH anyway, so we can't fix the anchor on the page. The link works, so it really is a non-issue and the failing CI builds are getting annoying.