### PR TITLE
Composer/lint: remove redundant duplicate script

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -70,10 +70,6 @@ jobs:
         if: ${{ startsWith( matrix.php, '7' ) && matrix.php != '7.0' }}
         run: composer lint7
 
-      - name: "Lint PHP files against parse errors - PHP 8.0 - 8.3"
-        if: ${{ matrix.php != 'nightly' && matrix.php >= 8.0 && matrix.php < 8.4 }}
+      - name: "Lint PHP files against parse errors - PHP 8.0+"
+        if: ${{ matrix.php == 'nightly' || matrix.php >= 8.0 }}
         run: composer lint-gte80 -- --checkstyle | cs2pr
-
-      - name: "Lint PHP files against parse errors - PHP >= 8.4"
-        if: ${{ matrix.php == 'nightly' || matrix.php >= 8.4 }}
-        run: composer lint-gte84

--- a/composer.json
+++ b/composer.json
@@ -67,9 +67,6 @@
 		"lint-gte80": [
 			"@php ./vendor/php-parallel-lint/php-parallel-lint/parallel-lint . -e php --show-deprecated --exclude vendor --exclude .git"
 		],
-		"lint-gte84": [
-			"@php ./vendor/php-parallel-lint/php-parallel-lint/parallel-lint . -e php --show-deprecated --exclude vendor --exclude .git"
-		],
 		"check-cs": [
 			"@php ./vendor/squizlabs/php_codesniffer/bin/phpcs --runtime-set testVersion 7.0-"
 		],
@@ -92,8 +89,7 @@
 	"scripts-descriptions": {
 		"lint7": "Check the PHP files for parse errors. (PHP 7.1 - 7.4)",
 		"lint70": "Check the PHP files for parse errors. (PHP 7.0)",
-		"lint-gte80": "Check the PHP files for parse errors. (PHP 8.0 - 8.3)",
-		"lint-gte84": "Check the PHP files for parse errors. (PHP 8.4+)",
+		"lint-gte80": "Check the PHP files for parse errors. (PHP 8.0+)",
 		"check-cs": "Check the PHP files for code style violations and best practices.",
 		"fix-cs": "Auto-fix code style violations in the PHP files.",
 		"test": "Run the unit tests without code coverage (PHPUnit < 10).",


### PR DESCRIPTION
The `lint-gte84` script became a duplicate of the `lint-gte80` script with the version drop of PHP < 7.0 in PR #192, so let's remove this duplication.