### PR TITLE
AssertContainsOnly::assertContainsNotOnlyInstancesOf(): fix incorrect param name

### DIFF
--- a/src/Polyfills/AssertContainsOnly.php
+++ b/src/Polyfills/AssertContainsOnly.php
@@ -31,14 +31,14 @@ trait AssertContainsOnly {
 	/**
 	 * Asserts that $haystack does not only contain instances of class or interface $type.
 	 *
-	 * @param string          $type     Class or interface name.
-	 * @param iterable<mixed> $haystack The variable to test.
-	 * @param string          $message  Optional failure message to display.
+	 * @param string          $className Class or interface name.
+	 * @param iterable<mixed> $haystack  The variable to test.
+	 * @param string          $message   Optional failure message to display.
 	 *
 	 * @return void
 	 */
-	final public static function assertContainsNotOnlyInstancesOf( string $type, $haystack, string $message = '' ) {
-		static::assertNotContainsOnly( $type, $haystack, false, $message );
+	final public static function assertContainsNotOnlyInstancesOf( string $className, $haystack, string $message = '' ) {
+		static::assertNotContainsOnly( $className, $haystack, false, $message );
 	}
 
 	/**


### PR DESCRIPTION
This could be problematic when tests use function calls with named parameters, so let's make sure the parameter name matches the one used in PHPUnit.
