### PR TITLE
Modernize: add visibility for class constants

### DIFF
--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -56,10 +56,6 @@
 		<exclude name="WordPressVIPMinimum.Security.EscapingVoidReturnFunctions"/>
 		<exclude name="WordPressVIPMinimum.Security.ProperEscapingFunction"/>
 
-		<!-- Exclude select "modern PHP" sniffs, which conflict with the minimum supported PHP version of this package. -->
-		<exclude name="PSR12.Properties.ConstantVisibility"/><!-- PHP 7.1+. -->
-		<exclude name="SlevomatCodingStandard.TypeHints.NullableTypeForNullDefaultValue"/><!-- PHP 7.1+. -->
-
 		<!-- As this repo is about providing assertions, "mixed" is a perfectly valid type. -->
 		<exclude name="SlevomatCodingStandard.TypeHints.DisallowMixedTypeHint"/>
 	</rule>

--- a/phpunitpolyfills-autoload.php
+++ b/phpunitpolyfills-autoload.php
@@ -22,7 +22,7 @@ if ( \class_exists( 'Yoast\PHPUnitPolyfills\Autoload', false ) === false ) {
 		 *
 		 * @var string
 		 */
-		const VERSION = '4.0.0-dev';
+		public const VERSION = '4.0.0-dev';
 
 		/**
 		 * Loads a class.

--- a/tests/Polyfills/AssertFileEqualsSpecializationsTest.php
+++ b/tests/Polyfills/AssertFileEqualsSpecializationsTest.php
@@ -16,15 +16,15 @@ final class AssertFileEqualsSpecializationsTest extends TestCase {
 
 	use AssertFileEqualsSpecializations;
 
-	const PATH_TO_EXPECTED = __DIR__ . '/Fixtures/AssertFileEqualsSpecialization_Expected.txt';
+	public const PATH_TO_EXPECTED = __DIR__ . '/Fixtures/AssertFileEqualsSpecialization_Expected.txt';
 
-	const PATH_TO_EQUALS = __DIR__ . '/Fixtures/AssertFileEqualsSpecialization_Equals.txt';
+	private const PATH_TO_EQUALS = __DIR__ . '/Fixtures/AssertFileEqualsSpecialization_Equals.txt';
 
-	const PATH_TO_NOT_EQUALS = __DIR__ . '/Fixtures/AssertFileEqualsSpecialization_NotEquals.txt';
+	private const PATH_TO_NOT_EQUALS = __DIR__ . '/Fixtures/AssertFileEqualsSpecialization_NotEquals.txt';
 
-	const PATH_TO_EQUALS_CI = __DIR__ . '/Fixtures/AssertFileEqualsSpecialization_EqualsCI.txt';
+	private const PATH_TO_EQUALS_CI = __DIR__ . '/Fixtures/AssertFileEqualsSpecialization_EqualsCI.txt';
 
-	const PATH_TO_NOT_EQUALS_CI = __DIR__ . '/Fixtures/AssertFileEqualsSpecialization_NotEqualsCI.txt';
+	private const PATH_TO_NOT_EQUALS_CI = __DIR__ . '/Fixtures/AssertFileEqualsSpecialization_NotEqualsCI.txt';
 
 	/**
 	 * Verify availability of the assertFileEqualsCanonicalizing() method.

--- a/tests/Polyfills/AssertObjectEqualsTest.php
+++ b/tests/Polyfills/AssertObjectEqualsTest.php
@@ -42,7 +42,7 @@ final class AssertObjectEqualsTest extends TestCase {
 	 *
 	 * @var string
 	 */
-	const COMPARATOR_EXCEPTION = InvalidComparisonMethodException::class;
+	private const COMPARATOR_EXCEPTION = InvalidComparisonMethodException::class;
 
 	/**
 	 * Verify availability of the assertObjectEquals() method.

--- a/tests/Polyfills/AssertObjectNotEqualsTest.php
+++ b/tests/Polyfills/AssertObjectNotEqualsTest.php
@@ -42,7 +42,7 @@ final class AssertObjectNotEqualsTest extends TestCase {
 	 *
 	 * @var string
 	 */
-	const COMPARATOR_EXCEPTION = InvalidComparisonMethodException::class;
+	private const COMPARATOR_EXCEPTION = InvalidComparisonMethodException::class;
 
 	/**
 	 * Verify availability of the assertObjectNotEquals() method.

--- a/tests/Polyfills/AssertionRenamesTest.php
+++ b/tests/Polyfills/AssertionRenamesTest.php
@@ -16,9 +16,9 @@ final class AssertionRenamesTest extends TestCase {
 
 	use AssertionRenames;
 
-	const NOT_EXISTENT_FILE = __DIR__ . \DIRECTORY_SEPARATOR . 'NotExisting.php';
+	private const NOT_EXISTENT_FILE = __DIR__ . \DIRECTORY_SEPARATOR . 'NotExisting.php';
 
-	const NOT_EXISTENT_DIR = __DIR__ . \DIRECTORY_SEPARATOR . 'NotExisting' . \DIRECTORY_SEPARATOR;
+	private const NOT_EXISTENT_DIR = __DIR__ . \DIRECTORY_SEPARATOR . 'NotExisting' . \DIRECTORY_SEPARATOR;
 
 	/**
 	 * Verify availability of the assertIsNotReadable() method.


### PR DESCRIPTION
... as supported by PHP since PHP 7.1.

Note: the `AssertFileEqualsSpecializationsTest::PATH_TO_EXPECTED` constant is declared as `public` as it is also used by tests in the `TestCaseTestTrait`.