### PR TITLE
Modernize: add scalar + return type declarations (wherever possible)

### DIFF
--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -161,4 +161,18 @@
 		<exclude-pattern>/tests/Polyfills/Fixtures/ValueObjectUnionReturnType\.php$</exclude-pattern>
 	</rule>
 
+
+	<!--
+	#############################################################################
+	TEMPORARY ADJUSTMENTS
+	Adjustments which should be removed once the associated issue has been resolved.
+	#############################################################################
+	-->
+
+	<!-- Bug in PHPCS. This exclusion can be removed once PHPCS PR #750 has been merged and released.
+		 https://github.com/PHPCSStandards/PHP_CodeSniffer/pull/750 -->
+	<rule ref="Squiz.Commenting.FunctionComment.IncorrectTypeHint">
+		<exclude-pattern>/src/Polyfills/AssertContainsOnly\.php$</exclude-pattern>
+	</rule>
+
 </ruleset>

--- a/phpstan-bootstrap.php
+++ b/phpstan-bootstrap.php
@@ -28,7 +28,7 @@ namespace PHPUnit\SebastianBergmann\Exporter {
 		 *
 		 * @return string
 		 */
-		public function export( $value, $indentation = 0 ) {}
+		public function export( $value, int $indentation = 0 ) {}
 	}
 }
 
@@ -47,6 +47,6 @@ namespace PHPUnitPHAR\SebastianBergmann\Exporter {
 		 *
 		 * @return string
 		 */
-		public function export( $value, $indentation = 0 ) {}
+		public function export( $value, int $indentation = 0 ) {}
 	}
 }

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -39,7 +39,7 @@ parameters:
 			path: src/Polyfills/ExpectUserDeprecation.php
 
 		-
-			message: '`^Call to static method PHPUnit\\Framework\\Assert::assertIsArray\(\) with mixed and mixed will always evaluate to false\.$`'
+			message: '`^Call to static method PHPUnit\\Framework\\Assert::assertIsArray\(\) with mixed and string will always evaluate to false\.$`'
 			count: 2
 			path: src/Polyfills/AssertIsList.php
 

--- a/phpunitpolyfills-autoload.php
+++ b/phpunitpolyfills-autoload.php
@@ -31,7 +31,7 @@ if ( \class_exists( 'Yoast\PHPUnitPolyfills\Autoload', false ) === false ) {
 		 *
 		 * @return bool
 		 */
-		public static function load( $className ) {
+		public static function load( string $className ): bool {
 			// Only load classes belonging to this library.
 			if ( \stripos( $className, 'Yoast\PHPUnitPolyfills' ) !== 0 ) {
 				return false;
@@ -124,7 +124,7 @@ if ( \class_exists( 'Yoast\PHPUnitPolyfills\Autoload', false ) === false ) {
 		 *
 		 * @return void
 		 */
-		public static function loadExpectExceptionMessageMatches() {
+		public static function loadExpectExceptionMessageMatches(): void {
 			if ( \method_exists( TestCase::class, 'expectExceptionMessageMatches' ) === false ) {
 				// PHPUnit < 8.4.0.
 				require_once __DIR__ . '/src/Polyfills/ExpectExceptionMessageMatches.php';
@@ -141,7 +141,7 @@ if ( \class_exists( 'Yoast\PHPUnitPolyfills\Autoload', false ) === false ) {
 		 *
 		 * @return void
 		 */
-		public static function loadAssertFileEqualsSpecializations() {
+		public static function loadAssertFileEqualsSpecializations(): void {
 			if ( \method_exists( Assert::class, 'assertFileEqualsIgnoringCase' ) === false ) {
 				// PHPUnit < 8.5.0.
 				require_once __DIR__ . '/src/Polyfills/AssertFileEqualsSpecializations.php';
@@ -158,7 +158,7 @@ if ( \class_exists( 'Yoast\PHPUnitPolyfills\Autoload', false ) === false ) {
 		 *
 		 * @return void
 		 */
-		public static function loadEqualToSpecializations() {
+		public static function loadEqualToSpecializations(): void {
 			if ( \method_exists( Assert::class, 'equalToWithDelta' ) === false ) {
 				// PHPUnit < 9.0.0.
 				require_once __DIR__ . '/src/Polyfills/EqualToSpecializations.php';
@@ -175,7 +175,7 @@ if ( \class_exists( 'Yoast\PHPUnitPolyfills\Autoload', false ) === false ) {
 		 *
 		 * @return void
 		 */
-		public static function loadAssertionRenames() {
+		public static function loadAssertionRenames(): void {
 			if ( \method_exists( Assert::class, 'assertMatchesRegularExpression' ) === false ) {
 				// PHPUnit < 9.1.0.
 				require_once __DIR__ . '/src/Polyfills/AssertionRenames.php';
@@ -192,7 +192,7 @@ if ( \class_exists( 'Yoast\PHPUnitPolyfills\Autoload', false ) === false ) {
 		 *
 		 * @return void
 		 */
-		public static function loadAssertClosedResource() {
+		public static function loadAssertClosedResource(): void {
 			if ( \method_exists( Assert::class, 'assertIsClosedResource' ) === false ) {
 				// PHPUnit < 9.3.0.
 				require_once __DIR__ . '/src/Polyfills/AssertClosedResource.php';
@@ -209,7 +209,7 @@ if ( \class_exists( 'Yoast\PHPUnitPolyfills\Autoload', false ) === false ) {
 		 *
 		 * @return void
 		 */
-		public static function loadAssertObjectEquals() {
+		public static function loadAssertObjectEquals(): void {
 			if ( \method_exists( Assert::class, 'assertObjectEquals' ) === false ) {
 				// PHPUnit < 9.4.0.
 				require_once __DIR__ . '/src/Polyfills/AssertObjectEquals.php';
@@ -226,7 +226,7 @@ if ( \class_exists( 'Yoast\PHPUnitPolyfills\Autoload', false ) === false ) {
 		 *
 		 * @return void
 		 */
-		public static function loadAssertIsList() {
+		public static function loadAssertIsList(): void {
 			if ( \method_exists( Assert::class, 'assertIsList' ) === false ) {
 				// PHPUnit < 10.0.0.
 				require_once __DIR__ . '/src/Polyfills/AssertIsList.php';
@@ -243,7 +243,7 @@ if ( \class_exists( 'Yoast\PHPUnitPolyfills\Autoload', false ) === false ) {
 		 *
 		 * @return void
 		 */
-		public static function loadAssertIgnoringLineEndings() {
+		public static function loadAssertIgnoringLineEndings(): void {
 			if ( \method_exists( Assert::class, 'assertStringEqualsStringIgnoringLineEndings' ) === false ) {
 				// PHPUnit < 10.0.0.
 				require_once __DIR__ . '/src/Polyfills/AssertIgnoringLineEndings.php';
@@ -260,7 +260,7 @@ if ( \class_exists( 'Yoast\PHPUnitPolyfills\Autoload', false ) === false ) {
 		 *
 		 * @return void
 		 */
-		public static function loadAssertObjectProperty() {
+		public static function loadAssertObjectProperty(): void {
 			if ( \method_exists( Assert::class, 'assertObjectHasProperty' ) === false ) {
 				// PHPUnit < 10.1.0.
 				require_once __DIR__ . '/src/Polyfills/AssertObjectProperty.php';
@@ -277,7 +277,7 @@ if ( \class_exists( 'Yoast\PHPUnitPolyfills\Autoload', false ) === false ) {
 		 *
 		 * @return void
 		 */
-		public static function loadAssertArrayWithListKeys() {
+		public static function loadAssertArrayWithListKeys(): void {
 			if ( \method_exists( Assert::class, 'assertArrayIsEqualToArrayOnlyConsideringListOfKeys' ) === false ) {
 				// PHPUnit < 11.0.0.
 				require_once __DIR__ . '/src/Polyfills/AssertArrayWithListKeys.php';
@@ -294,7 +294,7 @@ if ( \class_exists( 'Yoast\PHPUnitPolyfills\Autoload', false ) === false ) {
 		 *
 		 * @return void
 		 */
-		public static function loadExpectUserDeprecation() {
+		public static function loadExpectUserDeprecation(): void {
 			if ( \method_exists( TestCase::class, 'expectUserDeprecationMessage' ) === false ) {
 				// PHPUnit < 11.0.0.
 				require_once __DIR__ . '/src/Polyfills/ExpectUserDeprecation.php';
@@ -311,7 +311,7 @@ if ( \class_exists( 'Yoast\PHPUnitPolyfills\Autoload', false ) === false ) {
 		 *
 		 * @return void
 		 */
-		public static function loadAssertObjectNotEquals() {
+		public static function loadAssertObjectNotEquals(): void {
 			if ( \method_exists( Assert::class, 'assertObjectNotEquals' ) === false ) {
 				// PHPUnit < 11.2.0.
 				require_once __DIR__ . '/src/Polyfills/AssertObjectNotEquals.php';
@@ -328,7 +328,7 @@ if ( \class_exists( 'Yoast\PHPUnitPolyfills\Autoload', false ) === false ) {
 		 *
 		 * @return void
 		 */
-		public static function loadAssertContainsOnly() {
+		public static function loadAssertContainsOnly(): void {
 			if ( \method_exists( Assert::class, 'assertContainsOnlyIterable' ) === false ) {
 				// PHPUnit < 11.5.0.
 				require_once __DIR__ . '/src/Polyfills/AssertContainsOnly.php';
@@ -344,7 +344,7 @@ if ( \class_exists( 'Yoast\PHPUnitPolyfills\Autoload', false ) === false ) {
 		 *
 		 * @return void
 		 */
-		public static function loadTestCase() {
+		public static function loadTestCase(): void {
 			if ( \version_compare( self::getPHPUnitVersion(), '8.0.0', '<' ) ) {
 				// PHPUnit < 8.0.0.
 				require_once __DIR__ . '/src/TestCases/TestCasePHPUnitLte7.php';
@@ -360,7 +360,7 @@ if ( \class_exists( 'Yoast\PHPUnitPolyfills\Autoload', false ) === false ) {
 		 *
 		 * @return void
 		 */
-		public static function loadTestListenerDefaultImplementation() {
+		public static function loadTestListenerDefaultImplementation(): void {
 			require_once __DIR__ . '/src/TestListeners/TestListenerDefaultImplementationPHPUnitGte7.php';
 		}
 
@@ -369,7 +369,7 @@ if ( \class_exists( 'Yoast\PHPUnitPolyfills\Autoload', false ) === false ) {
 		 *
 		 * @return string Version number as a string.
 		 */
-		public static function getPHPUnitVersion() {
+		public static function getPHPUnitVersion(): string {
 			if ( \class_exists( '\PHPUnit\Runner\Version' ) ) {
 				return PHPUnit_Version::id();
 			}

--- a/src/Exceptions/InvalidComparisonMethodException.php
+++ b/src/Exceptions/InvalidComparisonMethodException.php
@@ -19,7 +19,7 @@ final class InvalidComparisonMethodException extends Exception {
 	 *
 	 * @return string
 	 */
-	public function __toString() {
+	public function __toString(): string {
 		return $this->getMessage() . \PHP_EOL;
 	}
 }

--- a/src/Helpers/ComparatorValidator.php
+++ b/src/Helpers/ComparatorValidator.php
@@ -48,7 +48,7 @@ final class ComparatorValidator {
 	 *
 	 * @throws InvalidComparisonMethodException When the comparator method does not comply with the requirements.
 	 */
-	public static function isValid( $expected, $actual, $method = 'equals' ) {
+	public static function isValid( $expected, $actual, string $method = 'equals' ): void {
 		/*
 		 * Verify the method exists.
 		 */

--- a/src/Helpers/ResourceHelper.php
+++ b/src/Helpers/ResourceHelper.php
@@ -28,7 +28,7 @@ final class ResourceHelper {
 	 *
 	 * @return bool
 	 */
-	public static function isResource( $actual ) {
+	public static function isResource( $actual ): bool {
 		return ( $actual !== null
 			&& \is_scalar( $actual ) === false
 			&& \is_array( $actual ) === false
@@ -42,7 +42,7 @@ final class ResourceHelper {
 	 *
 	 * @return bool
 	 */
-	public static function isClosedResource( $actual ) {
+	public static function isClosedResource( $actual ): bool {
 		$type = \gettype( $actual );
 
 		/*
@@ -92,7 +92,7 @@ final class ResourceHelper {
 	 *
 	 * @return bool
 	 */
-	public static function isResourceStateReliable( $actual ) {
+	public static function isResourceStateReliable( $actual ): bool {
 		try {
 			$type = @\get_resource_type( $actual );
 
@@ -118,7 +118,7 @@ final class ResourceHelper {
 	 *
 	 * @return bool
 	 */
-	public static function isIncompatiblePHPForLibXMLResources() {
+	public static function isIncompatiblePHPForLibXMLResources(): bool {
 		if ( \PHP_VERSION_ID >= 70100 && \PHP_VERSION_ID < 70134 ) {
 			return true;
 		}

--- a/src/Polyfills/AssertArrayWithListKeys.php
+++ b/src/Polyfills/AssertArrayWithListKeys.php
@@ -37,7 +37,7 @@ trait AssertArrayWithListKeys {
 	 *
 	 * @return void
 	 */
-	final public static function assertArrayIsEqualToArrayOnlyConsideringListOfKeys( array $expected, array $actual, array $keysToBeConsidered, string $message = '' ) {
+	final public static function assertArrayIsEqualToArrayOnlyConsideringListOfKeys( array $expected, array $actual, array $keysToBeConsidered, string $message = '' ): void {
 		$filteredExpected = [];
 		foreach ( $keysToBeConsidered as $key ) {
 			if ( isset( $expected[ $key ] ) ) {
@@ -68,7 +68,7 @@ trait AssertArrayWithListKeys {
 	 *
 	 * @return void
 	 */
-	final public static function assertArrayIsEqualToArrayIgnoringListOfKeys( array $expected, array $actual, array $keysToBeIgnored, string $message = '' ) {
+	final public static function assertArrayIsEqualToArrayIgnoringListOfKeys( array $expected, array $actual, array $keysToBeIgnored, string $message = '' ): void {
 		foreach ( $keysToBeIgnored as $key ) {
 			unset( $expected[ $key ], $actual[ $key ] );
 		}
@@ -89,7 +89,7 @@ trait AssertArrayWithListKeys {
 	 *
 	 * @return void
 	 */
-	final public static function assertArrayIsIdenticalToArrayOnlyConsideringListOfKeys( array $expected, array $actual, array $keysToBeConsidered, string $message = '' ) {
+	final public static function assertArrayIsIdenticalToArrayOnlyConsideringListOfKeys( array $expected, array $actual, array $keysToBeConsidered, string $message = '' ): void {
 		$keysToBeConsidered = \array_combine( $keysToBeConsidered, $keysToBeConsidered );
 		$expected           = \array_intersect_key( $expected, $keysToBeConsidered );
 		$actual             = \array_intersect_key( $actual, $keysToBeConsidered );
@@ -110,7 +110,7 @@ trait AssertArrayWithListKeys {
 	 *
 	 * @return void
 	 */
-	final public static function assertArrayIsIdenticalToArrayIgnoringListOfKeys( array $expected, array $actual, array $keysToBeIgnored, string $message = '' ) {
+	final public static function assertArrayIsIdenticalToArrayIgnoringListOfKeys( array $expected, array $actual, array $keysToBeIgnored, string $message = '' ): void {
 		foreach ( $keysToBeIgnored as $key ) {
 			unset( $expected[ $key ], $actual[ $key ] );
 		}

--- a/src/Polyfills/AssertClosedResource.php
+++ b/src/Polyfills/AssertClosedResource.php
@@ -27,7 +27,7 @@ trait AssertClosedResource {
 	 *
 	 * @return void
 	 */
-	public static function assertIsClosedResource( $actual, $message = '' ) {
+	public static function assertIsClosedResource( $actual, string $message = '' ): void {
 		$exporter = self::getPHPUnitExporterObject();
 		$msg      = \sprintf( 'Failed asserting that %s is of type "resource (closed)"', $exporter->export( $actual ) );
 
@@ -46,7 +46,7 @@ trait AssertClosedResource {
 	 *
 	 * @return void
 	 */
-	public static function assertIsNotClosedResource( $actual, $message = '' ) {
+	public static function assertIsNotClosedResource( $actual, string $message = '' ): void {
 		$exporter = self::getPHPUnitExporterObject();
 		$type     = $exporter->export( $actual );
 		if ( $type === 'NULL' ) {
@@ -77,7 +77,7 @@ trait AssertClosedResource {
 	 *
 	 * @return bool
 	 */
-	public static function shouldClosedResourceAssertionBeSkipped( $actual ) {
+	public static function shouldClosedResourceAssertionBeSkipped( $actual ): bool {
 		return ( ResourceHelper::isResourceStateReliable( $actual ) === false );
 	}
 

--- a/src/Polyfills/AssertContainsOnly.php
+++ b/src/Polyfills/AssertContainsOnly.php
@@ -35,7 +35,7 @@ trait AssertContainsOnly {
 	 *
 	 * @return void
 	 */
-	final public static function assertContainsNotOnlyInstancesOf( string $className, $haystack, string $message = '' ) {
+	final public static function assertContainsNotOnlyInstancesOf( string $className, iterable $haystack, string $message = '' ): void {
 		static::assertNotContainsOnly( $className, $haystack, false, $message );
 	}
 
@@ -47,7 +47,7 @@ trait AssertContainsOnly {
 	 *
 	 * @return void
 	 */
-	final public static function assertContainsOnlyArray( $haystack, string $message = '' ) {
+	final public static function assertContainsOnlyArray( iterable $haystack, string $message = '' ): void {
 		static::assertContainsOnly( 'array', $haystack, true, $message );
 	}
 
@@ -59,7 +59,7 @@ trait AssertContainsOnly {
 	 *
 	 * @return void
 	 */
-	final public static function assertContainsNotOnlyArray( $haystack, string $message = '' ) {
+	final public static function assertContainsNotOnlyArray( iterable $haystack, string $message = '' ): void {
 		static::assertNotContainsOnly( 'array', $haystack, true, $message );
 	}
 
@@ -71,7 +71,7 @@ trait AssertContainsOnly {
 	 *
 	 * @return void
 	 */
-	final public static function assertContainsOnlyBool( $haystack, string $message = '' ) {
+	final public static function assertContainsOnlyBool( iterable $haystack, string $message = '' ): void {
 		static::assertContainsOnly( 'bool', $haystack, true, $message );
 	}
 
@@ -83,7 +83,7 @@ trait AssertContainsOnly {
 	 *
 	 * @return void
 	 */
-	final public static function assertContainsNotOnlyBool( $haystack, string $message = '' ) {
+	final public static function assertContainsNotOnlyBool( iterable $haystack, string $message = '' ): void {
 		static::assertNotContainsOnly( 'bool', $haystack, true, $message );
 	}
 
@@ -95,7 +95,7 @@ trait AssertContainsOnly {
 	 *
 	 * @return void
 	 */
-	final public static function assertContainsOnlyCallable( $haystack, string $message = '' ) {
+	final public static function assertContainsOnlyCallable( iterable $haystack, string $message = '' ): void {
 		static::assertContainsOnly( 'callable', $haystack, true, $message );
 	}
 
@@ -107,7 +107,7 @@ trait AssertContainsOnly {
 	 *
 	 * @return void
 	 */
-	final public static function assertContainsNotOnlyCallable( $haystack, string $message = '' ) {
+	final public static function assertContainsNotOnlyCallable( iterable $haystack, string $message = '' ): void {
 		static::assertNotContainsOnly( 'callable', $haystack, true, $message );
 	}
 
@@ -119,7 +119,7 @@ trait AssertContainsOnly {
 	 *
 	 * @return void
 	 */
-	final public static function assertContainsOnlyFloat( $haystack, string $message = '' ) {
+	final public static function assertContainsOnlyFloat( iterable $haystack, string $message = '' ): void {
 		static::assertContainsOnly( 'float', $haystack, true, $message );
 	}
 
@@ -131,7 +131,7 @@ trait AssertContainsOnly {
 	 *
 	 * @return void
 	 */
-	final public static function assertContainsNotOnlyFloat( $haystack, string $message = '' ) {
+	final public static function assertContainsNotOnlyFloat( iterable $haystack, string $message = '' ): void {
 		static::assertNotContainsOnly( 'float', $haystack, true, $message );
 	}
 
@@ -143,7 +143,7 @@ trait AssertContainsOnly {
 	 *
 	 * @return void
 	 */
-	final public static function assertContainsOnlyInt( $haystack, string $message = '' ) {
+	final public static function assertContainsOnlyInt( iterable $haystack, string $message = '' ): void {
 		static::assertContainsOnly( 'int', $haystack, true, $message );
 	}
 
@@ -155,7 +155,7 @@ trait AssertContainsOnly {
 	 *
 	 * @return void
 	 */
-	final public static function assertContainsNotOnlyInt( $haystack, string $message = '' ) {
+	final public static function assertContainsNotOnlyInt( iterable $haystack, string $message = '' ): void {
 		static::assertNotContainsOnly( 'int', $haystack, true, $message );
 	}
 
@@ -167,7 +167,7 @@ trait AssertContainsOnly {
 	 *
 	 * @return void
 	 */
-	final public static function assertContainsOnlyIterable( $haystack, string $message = '' ) {
+	final public static function assertContainsOnlyIterable( iterable $haystack, string $message = '' ): void {
 		static::assertContainsOnly( 'iterable', $haystack, true, $message );
 	}
 
@@ -179,7 +179,7 @@ trait AssertContainsOnly {
 	 *
 	 * @return void
 	 */
-	final public static function assertContainsNotOnlyIterable( $haystack, string $message = '' ) {
+	final public static function assertContainsNotOnlyIterable( iterable $haystack, string $message = '' ): void {
 		static::assertNotContainsOnly( 'iterable', $haystack, true, $message );
 	}
 
@@ -191,7 +191,7 @@ trait AssertContainsOnly {
 	 *
 	 * @return void
 	 */
-	final public static function assertContainsOnlyNull( $haystack, string $message = '' ) {
+	final public static function assertContainsOnlyNull( iterable $haystack, string $message = '' ): void {
 		static::assertContainsOnly( 'null', $haystack, true, $message );
 	}
 
@@ -203,7 +203,7 @@ trait AssertContainsOnly {
 	 *
 	 * @return void
 	 */
-	final public static function assertContainsNotOnlyNull( $haystack, string $message = '' ) {
+	final public static function assertContainsNotOnlyNull( iterable $haystack, string $message = '' ): void {
 		static::assertNotContainsOnly( 'null', $haystack, true, $message );
 	}
 
@@ -215,7 +215,7 @@ trait AssertContainsOnly {
 	 *
 	 * @return void
 	 */
-	final public static function assertContainsOnlyNumeric( $haystack, string $message = '' ) {
+	final public static function assertContainsOnlyNumeric( iterable $haystack, string $message = '' ): void {
 		static::assertContainsOnly( 'numeric', $haystack, true, $message );
 	}
 
@@ -227,7 +227,7 @@ trait AssertContainsOnly {
 	 *
 	 * @return void
 	 */
-	final public static function assertContainsNotOnlyNumeric( $haystack, string $message = '' ) {
+	final public static function assertContainsNotOnlyNumeric( iterable $haystack, string $message = '' ): void {
 		static::assertNotContainsOnly( 'numeric', $haystack, true, $message );
 	}
 
@@ -239,7 +239,7 @@ trait AssertContainsOnly {
 	 *
 	 * @return void
 	 */
-	final public static function assertContainsOnlyObject( $haystack, string $message = '' ) {
+	final public static function assertContainsOnlyObject( iterable $haystack, string $message = '' ): void {
 		static::assertContainsOnly( 'object', $haystack, true, $message );
 	}
 
@@ -251,7 +251,7 @@ trait AssertContainsOnly {
 	 *
 	 * @return void
 	 */
-	final public static function assertContainsNotOnlyObject( $haystack, string $message = '' ) {
+	final public static function assertContainsNotOnlyObject( iterable $haystack, string $message = '' ): void {
 		static::assertNotContainsOnly( 'object', $haystack, true, $message );
 	}
 
@@ -263,7 +263,7 @@ trait AssertContainsOnly {
 	 *
 	 * @return void
 	 */
-	final public static function assertContainsOnlyResource( $haystack, string $message = '' ) {
+	final public static function assertContainsOnlyResource( iterable $haystack, string $message = '' ): void {
 		static::assertContainsOnly( 'resource', $haystack, true, $message );
 	}
 
@@ -275,7 +275,7 @@ trait AssertContainsOnly {
 	 *
 	 * @return void
 	 */
-	final public static function assertContainsNotOnlyResource( $haystack, string $message = '' ) {
+	final public static function assertContainsNotOnlyResource( iterable $haystack, string $message = '' ): void {
 		static::assertNotContainsOnly( 'resource', $haystack, true, $message );
 	}
 
@@ -287,7 +287,7 @@ trait AssertContainsOnly {
 	 *
 	 * @return void
 	 */
-	final public static function assertContainsOnlyClosedResource( $haystack, string $message = '' ) {
+	final public static function assertContainsOnlyClosedResource( iterable $haystack, string $message = '' ): void {
 		$exporter = self::getPHPUnitExporterObjectForContainsOnly();
 		$msg      = \sprintf( 'Failed asserting that %s contains only values of type "resource (closed)".', $exporter->export( $haystack ) );
 
@@ -316,7 +316,7 @@ trait AssertContainsOnly {
 	 *
 	 * @return void
 	 */
-	final public static function assertContainsNotOnlyClosedResource( $haystack, string $message = '' ) {
+	final public static function assertContainsNotOnlyClosedResource( iterable $haystack, string $message = '' ): void {
 		$exporter = self::getPHPUnitExporterObjectForContainsOnly();
 		$msg      = \sprintf( 'Failed asserting that %s does not contain only values of type "resource (closed)".', $exporter->export( $haystack ) );
 
@@ -345,7 +345,7 @@ trait AssertContainsOnly {
 	 *
 	 * @return void
 	 */
-	final public static function assertContainsOnlyScalar( $haystack, string $message = '' ) {
+	final public static function assertContainsOnlyScalar( iterable $haystack, string $message = '' ): void {
 		static::assertContainsOnly( 'scalar', $haystack, true, $message );
 	}
 
@@ -357,7 +357,7 @@ trait AssertContainsOnly {
 	 *
 	 * @return void
 	 */
-	final public static function assertContainsNotOnlyScalar( $haystack, string $message = '' ) {
+	final public static function assertContainsNotOnlyScalar( iterable $haystack, string $message = '' ): void {
 		static::assertNotContainsOnly( 'scalar', $haystack, true, $message );
 	}
 
@@ -369,7 +369,7 @@ trait AssertContainsOnly {
 	 *
 	 * @return void
 	 */
-	final public static function assertContainsOnlyString( $haystack, string $message = '' ) {
+	final public static function assertContainsOnlyString( iterable $haystack, string $message = '' ): void {
 		static::assertContainsOnly( 'string', $haystack, true, $message );
 	}
 
@@ -381,7 +381,7 @@ trait AssertContainsOnly {
 	 *
 	 * @return void
 	 */
-	final public static function assertContainsNotOnlyString( $haystack, string $message = '' ) {
+	final public static function assertContainsNotOnlyString( iterable $haystack, string $message = '' ): void {
 		static::assertNotContainsOnly( 'string', $haystack, true, $message );
 	}
 

--- a/src/Polyfills/AssertFileEqualsSpecializations.php
+++ b/src/Polyfills/AssertFileEqualsSpecializations.php
@@ -30,7 +30,7 @@ trait AssertFileEqualsSpecializations {
 	 *
 	 * @return void
 	 */
-	final public static function assertFileEqualsCanonicalizing( $expected, $actual, $message = '' ) {
+	final public static function assertFileEqualsCanonicalizing( string $expected, string $actual, string $message = '' ): void {
 		static::assertFileEquals( $expected, $actual, $message, true );
 	}
 
@@ -44,7 +44,7 @@ trait AssertFileEqualsSpecializations {
 	 *
 	 * @return void
 	 */
-	final public static function assertFileEqualsIgnoringCase( $expected, $actual, $message = '' ) {
+	final public static function assertFileEqualsIgnoringCase( string $expected, string $actual, string $message = '' ): void {
 		static::assertFileEquals( $expected, $actual, $message, false, true );
 	}
 
@@ -58,7 +58,7 @@ trait AssertFileEqualsSpecializations {
 	 *
 	 * @return void
 	 */
-	final public static function assertFileNotEqualsCanonicalizing( $expected, $actual, $message = '' ) {
+	final public static function assertFileNotEqualsCanonicalizing( string $expected, string $actual, string $message = '' ): void {
 		static::assertFileNotEquals( $expected, $actual, $message, true );
 	}
 
@@ -72,7 +72,7 @@ trait AssertFileEqualsSpecializations {
 	 *
 	 * @return void
 	 */
-	final public static function assertFileNotEqualsIgnoringCase( $expected, $actual, $message = '' ) {
+	final public static function assertFileNotEqualsIgnoringCase( string $expected, string $actual, string $message = '' ): void {
 		static::assertFileNotEquals( $expected, $actual, $message, false, true );
 	}
 
@@ -86,7 +86,7 @@ trait AssertFileEqualsSpecializations {
 	 *
 	 * @return void
 	 */
-	final public static function assertStringEqualsFileCanonicalizing( $expectedFile, $actualString, $message = '' ) {
+	final public static function assertStringEqualsFileCanonicalizing( string $expectedFile, string $actualString, string $message = '' ): void {
 		static::assertStringEqualsFile( $expectedFile, $actualString, $message, true );
 	}
 
@@ -100,7 +100,7 @@ trait AssertFileEqualsSpecializations {
 	 *
 	 * @return void
 	 */
-	final public static function assertStringEqualsFileIgnoringCase( $expectedFile, $actualString, $message = '' ) {
+	final public static function assertStringEqualsFileIgnoringCase( string $expectedFile, string $actualString, string $message = '' ): void {
 		static::assertStringEqualsFile( $expectedFile, $actualString, $message, false, true );
 	}
 
@@ -114,7 +114,7 @@ trait AssertFileEqualsSpecializations {
 	 *
 	 * @return void
 	 */
-	final public static function assertStringNotEqualsFileCanonicalizing( $expectedFile, $actualString, $message = '' ) {
+	final public static function assertStringNotEqualsFileCanonicalizing( string $expectedFile, string $actualString, string $message = '' ): void {
 		static::assertStringNotEqualsFile( $expectedFile, $actualString, $message, true );
 	}
 
@@ -128,7 +128,7 @@ trait AssertFileEqualsSpecializations {
 	 *
 	 * @return void
 	 */
-	final public static function assertStringNotEqualsFileIgnoringCase( $expectedFile, $actualString, $message = '' ) {
+	final public static function assertStringNotEqualsFileIgnoringCase( string $expectedFile, string $actualString, string $message = '' ): void {
 		static::assertStringNotEqualsFile( $expectedFile, $actualString, $message, false, true );
 	}
 }

--- a/src/Polyfills/AssertIgnoringLineEndings.php
+++ b/src/Polyfills/AssertIgnoringLineEndings.php
@@ -5,7 +5,6 @@ namespace Yoast\PHPUnitPolyfills\Polyfills;
 use PHPUnit\SebastianBergmann\Exporter\Exporter as Exporter_In_Phar_Old;
 use PHPUnitPHAR\SebastianBergmann\Exporter\Exporter as Exporter_In_Phar;
 use SebastianBergmann\Exporter\Exporter;
-use TypeError;
 
 /**
  * Polyfill the Assert::assertStringEqualsStringIgnoringLineEndings() and the
@@ -30,32 +29,8 @@ trait AssertIgnoringLineEndings {
 	 * @param string $message  Optional failure message to display.
 	 *
 	 * @return void
-	 *
-	 * @throws TypeError When any of the passed arguments do not meet the required type.
 	 */
-	final public static function assertStringEqualsStringIgnoringLineEndings( $expected, $actual, $message = '' ) {
-		/*
-		 * Parameter input validation.
-		 * In PHPUnit this is done via PHP native type declarations. Emulating this for the polyfill.
-		 * Note: using `is_scalar()` instead of `is_string()` as test files may not be using strict_types.
-		 */
-		if ( \is_scalar( $expected ) === false ) {
-			throw new TypeError(
-				\sprintf(
-					'Argument 1 passed to assertStringEqualsStringIgnoringLineEndings() must be of type string, %s given',
-					\gettype( $expected )
-				)
-			);
-		}
-		if ( \is_scalar( $actual ) === false ) {
-			throw new TypeError(
-				\sprintf(
-					'Argument 2 passed to assertStringEqualsStringIgnoringLineEndings() must be of type string, %s given',
-					\gettype( $actual )
-				)
-			);
-		}
-
+	final public static function assertStringEqualsStringIgnoringLineEndings( string $expected, string $actual, string $message = '' ): void {
 		$expected = self::normalizeLineEndingsForIgnoringLineEndingsAssertions( (string) $expected );
 		$exporter = self::getPHPUnitExporterObjectForIgnoringLineEndings();
 		$msg      = \sprintf(
@@ -81,32 +56,8 @@ trait AssertIgnoringLineEndings {
 	 * @param string $message  Optional failure message to display.
 	 *
 	 * @return void
-	 *
-	 * @throws TypeError When any of the passed arguments do not meet the required type.
 	 */
-	final public static function assertStringContainsStringIgnoringLineEndings( $needle, $haystack, $message = '' ) {
-		/*
-		 * Parameter input validation.
-		 * In PHPUnit this is done via PHP native type declarations. Emulating this for the polyfill.
-		 * Note: using `is_scalar()` instead of `is_string()` as test files may not be using strict_types.
-		 */
-		if ( \is_scalar( $needle ) === false ) {
-			throw new TypeError(
-				\sprintf(
-					'Argument 1 passed to assertStringContainsStringIgnoringLineEndings() must be of type string, %s given',
-					\gettype( $needle )
-				)
-			);
-		}
-		if ( \is_scalar( $haystack ) === false ) {
-			throw new TypeError(
-				\sprintf(
-					'Argument 2 passed to assertStringContainsStringIgnoringLineEndings() must be of type string, %s given',
-					\gettype( $haystack )
-				)
-			);
-		}
-
+	final public static function assertStringContainsStringIgnoringLineEndings( string $needle, string $haystack, string $message = '' ): void {
 		$needle   = self::normalizeLineEndingsForIgnoringLineEndingsAssertions( (string) $needle );
 		$haystack = self::normalizeLineEndingsForIgnoringLineEndingsAssertions( (string) $haystack );
 
@@ -120,7 +71,7 @@ trait AssertIgnoringLineEndings {
 	 *
 	 * @return string
 	 */
-	private static function normalizeLineEndingsForIgnoringLineEndingsAssertions( $value ) {
+	private static function normalizeLineEndingsForIgnoringLineEndingsAssertions( string $value ): string {
 		return \strtr(
 			$value,
 			[

--- a/src/Polyfills/AssertIsList.php
+++ b/src/Polyfills/AssertIsList.php
@@ -23,7 +23,7 @@ trait AssertIsList {
 	 *
 	 * @return void
 	 */
-	final public static function assertIsList( $array, $message = '' ) {
+	final public static function assertIsList( $array, string $message = '' ): void {
 		$msg = self::assertIsListFailureDescription( $array );
 		if ( $message !== '' ) {
 			$msg = $message . \PHP_EOL . $msg;
@@ -57,7 +57,7 @@ trait AssertIsList {
 	 *
 	 * @return string
 	 */
-	private static function assertIsListFailureDescription( $value ) {
+	private static function assertIsListFailureDescription( $value ): string {
 		$message = 'Failed asserting that %s is a list.';
 
 		if ( \is_object( $value ) ) {

--- a/src/Polyfills/AssertObjectEquals.php
+++ b/src/Polyfills/AssertObjectEquals.php
@@ -47,7 +47,7 @@ trait AssertObjectEquals {
 	 * @throws TypeError                        When any of the passed arguments do not meet the required type.
 	 * @throws InvalidComparisonMethodException When the comparator method does not comply with the requirements.
 	 */
-	final public static function assertObjectEquals( $expected, $actual, $method = 'equals', $message = '' ) {
+	final public static function assertObjectEquals( $expected, $actual, string $method = 'equals', string $message = '' ): void {
 		/*
 		 * Parameter input validation.
 		 * In PHPUnit this is done via PHP native type declarations. Emulating this for the polyfill.
@@ -68,18 +68,6 @@ trait AssertObjectEquals {
 					\gettype( $actual )
 				)
 			);
-		}
-
-		if ( \is_scalar( $method ) === false ) {
-			throw new TypeError(
-				\sprintf(
-					'Argument 3 passed to assertObjectEquals() must be of the type string, %s given',
-					\gettype( $method )
-				)
-			);
-		}
-		else {
-			$method = (string) $method;
 		}
 
 		/*

--- a/src/Polyfills/AssertObjectNotEquals.php
+++ b/src/Polyfills/AssertObjectNotEquals.php
@@ -45,7 +45,7 @@ trait AssertObjectNotEquals {
 	 * @throws TypeError                        When any of the passed arguments do not meet the required type.
 	 * @throws InvalidComparisonMethodException When the comparator method does not comply with the requirements.
 	 */
-	final public static function assertObjectNotEquals( $expected, $actual, $method = 'equals', $message = '' ) {
+	final public static function assertObjectNotEquals( $expected, $actual, string $method = 'equals', string $message = '' ): void {
 		/*
 		 * Parameter input validation.
 		 * In PHPUnit this is done via PHP native type declarations. Emulating this for the polyfill.
@@ -66,18 +66,6 @@ trait AssertObjectNotEquals {
 					\gettype( $actual )
 				)
 			);
-		}
-
-		if ( \is_scalar( $method ) === false ) {
-			throw new TypeError(
-				\sprintf(
-					'Argument 3 passed to assertObjectNotEquals() must be of the type string, %s given',
-					\gettype( $method )
-				)
-			);
-		}
-		else {
-			$method = (string) $method;
 		}
 
 		/*

--- a/src/Polyfills/AssertObjectProperty.php
+++ b/src/Polyfills/AssertObjectProperty.php
@@ -34,7 +34,7 @@ trait AssertObjectProperty {
 	 *
 	 * @throws TypeError When any of the passed arguments do not meet the required type.
 	 */
-	final public static function assertObjectHasProperty( $propertyName, $object, $message = '' ) {
+	final public static function assertObjectHasProperty( $propertyName, $object, string $message = '' ): void {
 		/*
 		 * Parameter input validation.
 		 * In PHPUnit this is done via PHP native type declarations. Emulating this for the polyfill,
@@ -92,7 +92,7 @@ trait AssertObjectProperty {
 	 *
 	 * @throws TypeError When any of the passed arguments do not meet the required type.
 	 */
-	final public static function assertObjectNotHasProperty( $propertyName, $object, $message = '' ) {
+	final public static function assertObjectNotHasProperty( $propertyName, $object, string $message = '' ): void {
 		/*
 		 * Parameter input validation.
 		 * In PHPUnit this is done via PHP native type declarations. Emulating this for the polyfill,
@@ -146,7 +146,7 @@ trait AssertObjectProperty {
 	 *
 	 * @return string
 	 */
-	private static function assertObjectHasPropertyFailureDescription( $object ) {
+	private static function assertObjectHasPropertyFailureDescription( $object ): string {
 		return \sprintf(
 			'Failed asserting that object of class "%s"',
 			\get_class( $object )

--- a/src/Polyfills/AssertionRenames.php
+++ b/src/Polyfills/AssertionRenames.php
@@ -51,7 +51,7 @@ trait AssertionRenames {
 	 *
 	 * @return void
 	 */
-	final public static function assertIsNotReadable( $filename, $message = '' ) {
+	final public static function assertIsNotReadable( string $filename, string $message = '' ): void {
 		static::assertNotIsReadable( $filename, $message );
 	}
 
@@ -63,7 +63,7 @@ trait AssertionRenames {
 	 *
 	 * @return void
 	 */
-	final public static function assertIsNotWritable( $filename, $message = '' ) {
+	final public static function assertIsNotWritable( string $filename, string $message = '' ): void {
 		static::assertNotIsWritable( $filename, $message );
 	}
 
@@ -75,7 +75,7 @@ trait AssertionRenames {
 	 *
 	 * @return void
 	 */
-	final public static function assertDirectoryDoesNotExist( $directory, $message = '' ) {
+	final public static function assertDirectoryDoesNotExist( string $directory, string $message = '' ): void {
 		static::assertDirectoryNotExists( $directory, $message );
 	}
 
@@ -87,7 +87,7 @@ trait AssertionRenames {
 	 *
 	 * @return void
 	 */
-	final public static function assertDirectoryIsNotReadable( $directory, $message = '' ) {
+	final public static function assertDirectoryIsNotReadable( string $directory, string $message = '' ): void {
 		static::assertDirectoryNotIsReadable( $directory, $message );
 	}
 
@@ -99,7 +99,7 @@ trait AssertionRenames {
 	 *
 	 * @return void
 	 */
-	final public static function assertDirectoryIsNotWritable( $directory, $message = '' ) {
+	final public static function assertDirectoryIsNotWritable( string $directory, string $message = '' ): void {
 		static::assertDirectoryNotIsWritable( $directory, $message );
 	}
 
@@ -111,7 +111,7 @@ trait AssertionRenames {
 	 *
 	 * @return void
 	 */
-	final public static function assertFileDoesNotExist( $filename, $message = '' ) {
+	final public static function assertFileDoesNotExist( string $filename, string $message = '' ): void {
 		static::assertFileNotExists( $filename, $message );
 	}
 
@@ -123,7 +123,7 @@ trait AssertionRenames {
 	 *
 	 * @return void
 	 */
-	final public static function assertFileIsNotReadable( $file, $message = '' ) {
+	final public static function assertFileIsNotReadable( string $file, string $message = '' ): void {
 		static::assertFileNotIsReadable( $file, $message );
 	}
 
@@ -135,7 +135,7 @@ trait AssertionRenames {
 	 *
 	 * @return void
 	 */
-	final public static function assertFileIsNotWritable( $file, $message = '' ) {
+	final public static function assertFileIsNotWritable( string $file, string $message = '' ): void {
 		static::assertFileNotIsWritable( $file, $message );
 	}
 
@@ -148,7 +148,7 @@ trait AssertionRenames {
 	 *
 	 * @return void
 	 */
-	final public static function assertMatchesRegularExpression( $pattern, $string, $message = '' ) {
+	final public static function assertMatchesRegularExpression( string $pattern, string $string, string $message = '' ): void {
 		static::assertRegExp( $pattern, $string, $message );
 	}
 
@@ -161,7 +161,7 @@ trait AssertionRenames {
 	 *
 	 * @return void
 	 */
-	final public static function assertDoesNotMatchRegularExpression( $pattern, $string, $message = '' ) {
+	final public static function assertDoesNotMatchRegularExpression( string $pattern, string $string, string $message = '' ): void {
 		static::assertNotRegExp( $pattern, $string, $message );
 	}
 }

--- a/src/Polyfills/EqualToSpecializations.php
+++ b/src/Polyfills/EqualToSpecializations.php
@@ -26,7 +26,7 @@ trait EqualToSpecializations {
 	 *
 	 * @return IsEqual An isEqual constraint instance.
 	 */
-	final public static function equalToCanonicalizing( $value ) {
+	final public static function equalToCanonicalizing( $value ): IsEqual {
 		return static::equalTo( $value, 0.0, 10, true, false );
 	}
 
@@ -37,7 +37,7 @@ trait EqualToSpecializations {
 	 *
 	 * @return IsEqual An isEqual constraint instance.
 	 */
-	final public static function equalToIgnoringCase( $value ) {
+	final public static function equalToIgnoringCase( $value ): IsEqual {
 		return static::equalTo( $value, 0.0, 10, false, true );
 	}
 
@@ -49,7 +49,7 @@ trait EqualToSpecializations {
 	 *
 	 * @return IsEqual An isEqual constraint instance.
 	 */
-	final public static function equalToWithDelta( $value, $delta ) {
+	final public static function equalToWithDelta( $value, float $delta ): IsEqual {
 		return static::equalTo( $value, $delta, 10, false, false );
 	}
 }

--- a/src/Polyfills/ExpectExceptionMessageMatches.php
+++ b/src/Polyfills/ExpectExceptionMessageMatches.php
@@ -25,7 +25,7 @@ trait ExpectExceptionMessageMatches {
 	 *
 	 * @return void
 	 */
-	final protected function expectExceptionMessageMatches( $regularExpression ) {
+	final protected function expectExceptionMessageMatches( string $regularExpression ): void {
 		$this->expectExceptionMessageRegExp( $regularExpression );
 	}
 }

--- a/src/Polyfills/ExpectUserDeprecation.php
+++ b/src/Polyfills/ExpectUserDeprecation.php
@@ -25,7 +25,7 @@ trait ExpectUserDeprecation {
 	 *
 	 * @return void
 	 */
-	final protected function expectUserDeprecationMessage( string $expectedUserDeprecationMessage ) {
+	final protected function expectUserDeprecationMessage( string $expectedUserDeprecationMessage ): void {
 		if ( \method_exists( TestCase::class, 'expectDeprecationMessage' ) ) {
 			// PHPUnit 8.4.0 - 9.x.
 			$this->expectDeprecation();
@@ -45,7 +45,7 @@ trait ExpectUserDeprecation {
 	 *
 	 * @return void
 	 */
-	final protected function expectUserDeprecationMessageMatches( string $expectedUserDeprecationMessageRegularExpression ) {
+	final protected function expectUserDeprecationMessageMatches( string $expectedUserDeprecationMessageRegularExpression ): void {
 		if ( \method_exists( TestCase::class, 'expectDeprecationMessageMatches' ) ) {
 			// PHPUnit 8.4.0 - 9.x.
 			$this->expectDeprecation();

--- a/src/TestListeners/TestListenerSnakeCaseMethods.php
+++ b/src/TestListeners/TestListenerSnakeCaseMethods.php
@@ -27,7 +27,7 @@ trait TestListenerSnakeCaseMethods {
 	 *
 	 * @return void
 	 */
-	public function add_error( $test, $e, $time ) {}
+	public function add_error( Test $test, Throwable $e, float $time ): void {}
 
 	/**
 	 * A warning occurred.
@@ -40,7 +40,7 @@ trait TestListenerSnakeCaseMethods {
 	 *
 	 * @return void
 	 */
-	public function add_warning( $test, $e, $time ) {}
+	public function add_warning( Test $test, Warning $e, float $time ): void {}
 
 	/**
 	 * A failure occurred.
@@ -51,7 +51,7 @@ trait TestListenerSnakeCaseMethods {
 	 *
 	 * @return void
 	 */
-	public function add_failure( $test, $e, $time ) {}
+	public function add_failure( Test $test, AssertionFailedError $e, float $time ): void {}
 
 	/**
 	 * Incomplete test.
@@ -62,7 +62,7 @@ trait TestListenerSnakeCaseMethods {
 	 *
 	 * @return void
 	 */
-	public function add_incomplete_test( $test, $e, $time ) {}
+	public function add_incomplete_test( Test $test, Throwable $e, float $time ): void {}
 
 	/**
 	 * Risky test.
@@ -73,7 +73,7 @@ trait TestListenerSnakeCaseMethods {
 	 *
 	 * @return void
 	 */
-	public function add_risky_test( $test, $e, $time ) {}
+	public function add_risky_test( Test $test, Throwable $e, float $time ): void {}
 
 	/**
 	 * Skipped test.
@@ -84,7 +84,7 @@ trait TestListenerSnakeCaseMethods {
 	 *
 	 * @return void
 	 */
-	public function add_skipped_test( $test, $e, $time ) {}
+	public function add_skipped_test( Test $test, Throwable $e, float $time ): void {}
 
 	/**
 	 * A test suite started.
@@ -93,7 +93,7 @@ trait TestListenerSnakeCaseMethods {
 	 *
 	 * @return void
 	 */
-	public function start_test_suite( $suite ) {}
+	public function start_test_suite( TestSuite $suite ): void {}
 
 	/**
 	 * A test suite ended.
@@ -102,7 +102,7 @@ trait TestListenerSnakeCaseMethods {
 	 *
 	 * @return void
 	 */
-	public function end_test_suite( $suite ) {}
+	public function end_test_suite( TestSuite $suite ): void {}
 
 	/**
 	 * A test started.
@@ -111,7 +111,7 @@ trait TestListenerSnakeCaseMethods {
 	 *
 	 * @return void
 	 */
-	public function start_test( $test ) {}
+	public function start_test( Test $test ): void {}
 
 	/**
 	 * A test ended.
@@ -121,5 +121,5 @@ trait TestListenerSnakeCaseMethods {
 	 *
 	 * @return void
 	 */
-	public function end_test( $test, $time ) {}
+	public function end_test( Test $test, float $time ): void {}
 }

--- a/tests/Polyfills/AssertIgnoringLineEndingsTest.php
+++ b/tests/Polyfills/AssertIgnoringLineEndingsTest.php
@@ -38,14 +38,13 @@ final class AssertIgnoringLineEndingsTest extends TestCase {
 	 */
 	#[DataProvider( 'dataThrowsTypeErrorOnInvalidType' )]
 	public function testAssertStringEqualsStringIgnoringLineEndingsThrowsTypeErrorOnInvalidTypeArg1( $input ) {
-		if ( \PHP_VERSION_ID >= 80100
-			&& \version_compare( PHPUnit_Version::id(), '10.0.0', '>=' )
-		) {
+		if ( \PHP_VERSION_ID >= 80000 ) {
 			$msg = 'assertStringEqualsStringIgnoringLineEndings(): Argument #1 ($expected) must be of type string, ';
 		}
 		else {
 			// PHP 7.
-			$msg = 'Argument 1 passed to assertStringEqualsStringIgnoringLineEndings() must be of type string, ';
+			$msg  = 'Argument 1 passed to Yoast\\PHPUnitPolyfills\\Tests\\Polyfills\\AssertIgnoringLineEndingsTest';
+			$msg .= '::assertStringEqualsStringIgnoringLineEndings() must be of the type string, ';
 		}
 
 		$this->expectException( TypeError::class );
@@ -66,14 +65,13 @@ final class AssertIgnoringLineEndingsTest extends TestCase {
 	 */
 	#[DataProvider( 'dataThrowsTypeErrorOnInvalidType' )]
 	public function testAssertStringEqualsStringIgnoringLineEndingsThrowsTypeErrorOnInvalidTypeArg2( $input ) {
-		if ( \PHP_VERSION_ID >= 80100
-			&& \version_compare( PHPUnit_Version::id(), '10.0.0', '>=' )
-		) {
+		if ( \PHP_VERSION_ID >= 80000 ) {
 			$msg = 'assertStringEqualsStringIgnoringLineEndings(): Argument #2 ($actual) must be of type string, ';
 		}
 		else {
 			// PHP 7.
-			$msg = 'Argument 2 passed to assertStringEqualsStringIgnoringLineEndings() must be of type string, ';
+			$msg  = 'Argument 2 passed to Yoast\\PHPUnitPolyfills\\Tests\\Polyfills\\AssertIgnoringLineEndingsTest';
+			$msg .= '::assertStringEqualsStringIgnoringLineEndings() must be of the type string, ';
 		}
 
 		$this->expectException( TypeError::class );
@@ -212,14 +210,13 @@ final class AssertIgnoringLineEndingsTest extends TestCase {
 	 */
 	#[DataProvider( 'dataThrowsTypeErrorOnInvalidType' )]
 	public function testAssertStringContainsStringIgnoringLineEndingsThrowsTypeErrorOnInvalidTypeArg1( $input ) {
-		if ( \PHP_VERSION_ID >= 80100
-			&& \version_compare( PHPUnit_Version::id(), '10.0.0', '>=' )
-		) {
+		if ( \PHP_VERSION_ID >= 80000 ) {
 			$msg = 'assertStringContainsStringIgnoringLineEndings(): Argument #1 ($needle) must be of type string, ';
 		}
 		else {
 			// PHP 7.
-			$msg = 'Argument 1 passed to assertStringContainsStringIgnoringLineEndings() must be of type string, ';
+			$msg  = 'Argument 1 passed to Yoast\\PHPUnitPolyfills\\Tests\\Polyfills\\AssertIgnoringLineEndingsTest';
+			$msg .= '::assertStringContainsStringIgnoringLineEndings() must be of the type string, ';
 		}
 
 		$this->expectException( TypeError::class );
@@ -240,14 +237,13 @@ final class AssertIgnoringLineEndingsTest extends TestCase {
 	 */
 	#[DataProvider( 'dataThrowsTypeErrorOnInvalidType' )]
 	public function testAssertStringContainsStringIgnoringLineEndingsThrowsTypeErrorOnInvalidTypeArg2( $input ) {
-		if ( \PHP_VERSION_ID >= 80100
-			&& \version_compare( PHPUnit_Version::id(), '10.0.0', '>=' )
-		) {
+		if ( \PHP_VERSION_ID >= 80000 ) {
 			$msg = 'assertStringContainsStringIgnoringLineEndings(): Argument #2 ($haystack) must be of type string, ';
 		}
 		else {
 			// PHP 7.
-			$msg = 'Argument 2 passed to assertStringContainsStringIgnoringLineEndings() must be of type string, ';
+			$msg  = 'Argument 2 passed to Yoast\\PHPUnitPolyfills\\Tests\\Polyfills\\AssertIgnoringLineEndingsTest';
+			$msg .= '::assertStringContainsStringIgnoringLineEndings() must be of the type string, ';
 		}
 
 		$this->expectException( TypeError::class );

--- a/tests/Polyfills/AssertObjectEqualsTest.php
+++ b/tests/Polyfills/AssertObjectEqualsTest.php
@@ -145,9 +145,7 @@ final class AssertObjectEqualsTest extends TestCase {
 	public function testAssertObjectEqualsFailsOnMethodNotJuggleableToString() {
 		$this->expectException( TypeError::class );
 
-		if ( \PHP_VERSION_ID >= 80000
-			&& \version_compare( PHPUnit_Version::id(), '9.4.0', '>=' )
-		) {
+		if ( \PHP_VERSION_ID >= 80000 ) {
 			$msg = 'assertObjectEquals(): Argument #3 ($method) must be of type string, array given';
 			$this->expectExceptionMessage( $msg );
 		}

--- a/tests/Polyfills/AssertObjectNotEqualsTest.php
+++ b/tests/Polyfills/AssertObjectNotEqualsTest.php
@@ -145,9 +145,7 @@ final class AssertObjectNotEqualsTest extends TestCase {
 	public function testAssertObjectNotEqualsFailsOnMethodNotJuggleableToString() {
 		$this->expectException( TypeError::class );
 
-		if ( \PHP_VERSION_ID >= 80000
-			&& \version_compare( PHPUnit_Version::id(), '11.2.0', '>=' )
-		) {
+		if ( \PHP_VERSION_ID >= 80000 ) {
 			$msg = 'assertObjectNotEquals(): Argument #3 ($method) must be of type string, array given';
 			$this->expectExceptionMessage( $msg );
 		}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -14,7 +14,7 @@ if ( \defined( '__PHPUNIT_PHAR__' ) ) {
 		 *
 		 * @return bool
 		 */
-		static function ( $fqClassName ) {
+		static function ( string $fqClassName ): bool {
 			// Only try & load our own classes.
 			if ( \stripos( $fqClassName, 'Yoast\PHPUnitPolyfills\Tests\\' ) !== 0 ) {
 				return false;


### PR DESCRIPTION
In line with the new minimum of PHPUnit 7.x, the assertions in the PHPUnit Polyfills will now have both parameter as well as return type declarations (wherever possible considering the minimum supported PHP version of PHP 7.1).

Additional type declarations will be added in future majors if/when the minimum supported PHP version allows for it.

Includes removing polyfilled inline type checks for assertions which were introduced in PHPUnit with declared types, but for which the polyfills couldn't type the parameters prior to this.

Includes minor adjustments to exception expectations in the tests to allow for the PHP native `TypeError`s - in contrast to the emulated ones.

Notes:
* `AssertObjectProperty`: the `string` type for the `$propertyName` parameter for the `assertObject[Not]HasProperty()` has not been applied as it would invalidate the type check (as we can't enforce `strict_types` for tests using the assertion).

Refs:
* https://github.com/sebastianbergmann/phpunit/commit/852e5405df1f3f8b46ae54963472b6226f8559e5
* https://github.com/sebastianbergmann/phpunit/commit/a7ab2b9b53c88a9020babcd547d6d71279fba087
