### PR TITLE
Dependabot: remove Composer ecosystem

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,18 +18,3 @@ updates:
       - "Type: chores/QA"
     reviewers:
       - "jrfnl"
-
-  # Maintain dependencies for Composer.
-  - package-ecosystem: "composer"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-    open-pull-requests-limit: 5 # Set to 0 to (temporarily) disable.
-    target-branch: "1.x"
-    versioning-strategy: widen
-    commit-message:
-      prefix: "Composer:"
-    labels:
-      - "Type: chores/QA"
-    reviewers:
-      - "jrfnl"


### PR DESCRIPTION
Composer checks have started to run into trouble with the minimum PHP version vs the YoastCS dependency (which has a higher minimum PHP version).

As Dependabot has never made a useful contribution for the Composer dependencies anyway AND there are only a few dependencies, we may as well drop it to get rid of the incessant error notifications.

Ref: https://github.com/Yoast/PHPUnit-Polyfills/network/updates/958266171
