### PR TITLE
GH Actions/test: fix rate limiting issue

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -289,6 +289,7 @@ jobs:
           coverage: ${{ matrix.coverage && 'xdebug' || 'none' }}
         env:
           fail-fast: true
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       # YoastCS 3.0 has a PHP 7.2 minimum which conflicts with the requirements of this package.
       - name: 'Composer: remove YoastCS'


### PR DESCRIPTION
If a tool version is specified, workflows can run into rate limiting issues with the GitHub API. To get round this, the `GITHUB_TOKEN` needs to be provided.

The `tools` key is also used in the CS workflows, but has, so far, not yielded any problematic builds for those. If needs be, the same tweak can be made to those job steps if those jobs would start to hit rate limits in the future.

Ref: https://github.com/shivammathur/setup-php#wrench-tools-support