### PR TITLE
GH Actions: prevent more rate limiting issues

### DIFF
--- a/.github/workflows/cs.yml
+++ b/.github/workflows/cs.yml
@@ -32,6 +32,9 @@ jobs:
           php-version: 'latest'
           coverage: none
           tools: cs2pr
+        env:
+          fail-fast: true
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       # Install dependencies and handle caching in one go.
       # @link https://github.com/marketplace/actions/install-php-dependencies-with-composer
@@ -70,6 +73,9 @@ jobs:
           php-version: '7.4'
           coverage: none
           tools: phpstan:2.x
+        env:
+          fail-fast: true
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       # Install dependencies and handle caching in one go.
       # Dependencies need to be installed to make sure the PHPUnit classes are recognized.

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -36,6 +36,8 @@ jobs:
           php-version: ${{ matrix.php }}
           ini-values: zend.assertions=1, error_reporting=-1, display_errors=On
           coverage: none
+        env:
+          fail-fast: true
 
       # YoastCS 3.0 has a PHP 7.2 minimum which conflicts with the requirements of this package.
       - name: 'Composer: remove YoastCS'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -107,6 +107,8 @@ jobs:
           php-version: ${{ matrix.php }}
           ini-values: zend.assertions=1, error_reporting=-1, display_errors=On
           coverage: ${{ matrix.coverage == true && 'xdebug' || 'none' }}
+        env:
+          fail-fast: true
 
       # YoastCS 3.0 has a PHP 7.2 minimum which conflicts with the requirements of this package.
       - name: 'Composer: remove YoastCS'


### PR DESCRIPTION
Follow up on #244.

This adds the `GITHUB_TOKEN` to get round the rate limiting where necessary.

It also adds `fail-fast` to get `setup-php` to exit with a non-zero exit code if something required in `tools` could not be installed (or other customizations failed). This prevents running unnecessary interim steps if a later step would never be able to succeed anyway.