### PR TITLE
Changelog for the 4.0.0 release and other documentation updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,45 @@ This projects adheres to [Keep a CHANGELOG](http://keepachangelog.com/) and uses
 
 _Nothing yet._
 
+## [4.0.0] - 2025-02-09
+
+### PHPUnit 12 support
+
+This release updates the PHPUnit Polyfills to allow for _"writing your tests for PHPUnit 12 and running them all the way back to PHPUnit 7"_. \[*\]
+
+Please keep in mind that the PHPUnit Polyfills provide _forward_-compatibility. This means that features which PHPUnit no longer supports in PHPUnit 12.x, are also no longer supported in the 4.0 release of the PHPUnit Polyfills.
+
+Please refer to the [PHPUnit 12 release notification] and [PHPUnit 12 changelog] to inform your decision on whether or not to upgrade (yet).
+
+Projects which don't use any of the new or removed functionality in their test suite, can, of course, use the PHPUnit Polyfills 1.x, 2.x, 3.x and 4.x series side-by-side, like so `composer require --dev yoast/phpunit-polyfills:"^1.0 || ^2.0 || ^3.0 || ^4.0"`.
+
+[PHPUnit 12 release notification]: https://phpunit.de/announcements/phpunit-12.html
+[PHPUnit 12 changelog]:            https://github.com/sebastianbergmann/phpunit/blob/12.0.2/ChangeLog-12.0.md
+
+\[*\]: _Note: Releases from the PHPUnit Polyfills 4.x branch will support running tests on PHPUnit 7.5.0 - 9.x, 11.x and 12.x, but will not allow for running tests on PHPUnit 10 (for reasons explained in [#200])._
+_In practical terms, the net effect of this is that tests on PHP 8.1 will run on PHPUnit 9 instead of PHPUnit 10. Other than that, there is no impact._
+
+
+### Changelog
+
+#### Changed
+* Composer: allow for installation of PHPUnit 12.x. PR [#247]
+* Scalar parameter type declarations and return type declarations are now used where possible. PR [#241]
+* General housekeeping.
+
+#### Removed
+* Support for PHP < 7.1. PR [#238].
+* Support for PHPUnit < 7.5.0. PR [#239].
+* The `Yoast\PHPUnitPolyfills\Polyfills\AssertIsType` trait which is no longer needed now support for PHPUnit < 7.5 has been dropped. PR [#239].
+* The `Yoast\PHPUnitPolyfills\Polyfills\AssertStringContains` trait which is no longer needed now support for PHPUnit < 7.5 has been dropped. PR [#239].
+* The `Yoast\PHPUnitPolyfills\Polyfills\AssertEqualsSpecializations` trait which is no longer needed now support for PHPUnit < 7.5 has been dropped. PR [#239].
+
+[#238]: https://github.com/Yoast/PHPUnit-Polyfills/pull/238
+[#239]: https://github.com/Yoast/PHPUnit-Polyfills/pull/239
+[#241]: https://github.com/Yoast/PHPUnit-Polyfills/pull/241
+[#247]: https://github.com/Yoast/PHPUnit-Polyfills/pull/247
+
+
 ## [3.1.2] - 2025-02-09
 
 This is a maintenance release.
@@ -400,6 +439,7 @@ Initial release.
 
 
 [Unreleased]: https://github.com/Yoast/PHPUnit-Polyfills/compare/main...HEAD
+[4.0.0]: https://github.com/Yoast/PHPUnit-Polyfills/compare/3.1.2...4.0.0
 [3.1.2]: https://github.com/Yoast/PHPUnit-Polyfills/compare/3.1.1...3.1.2
 [3.1.1]: https://github.com/Yoast/PHPUnit-Polyfills/compare/3.1.0...3.1.1
 [3.1.0]: https://github.com/Yoast/PHPUnit-Polyfills/compare/3.0.0...3.1.0

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ PHPUnit Polyfills
 [![CS Build Status](https://github.com/Yoast/PHPUnit-Polyfills/actions/workflows/cs.yml/badge.svg)](https://github.com/Yoast/PHPUnit-Polyfills/actions/workflows/cs.yml)
 [![Lint Build Status](https://github.com/Yoast/PHPUnit-Polyfills/actions/workflows/lint.yml/badge.svg)](https://github.com/Yoast/PHPUnit-Polyfills/actions/workflows/lint.yml)
 [![Test Build Status](https://github.com/Yoast/PHPUnit-Polyfills/actions/workflows/test.yml/badge.svg)](https://github.com/Yoast/PHPUnit-Polyfills/actions/workflows/test.yml)
-[![Coverage Status](https://coveralls.io/repos/github/Yoast/PHPUnit-Polyfills/badge.svg?branch=3.x)](https://coveralls.io/github/Yoast/PHPUnit-Polyfills?branch=3.x)
+[![Coverage Status](https://coveralls.io/repos/github/Yoast/PHPUnit-Polyfills/badge.svg?branch=4.x)](https://coveralls.io/github/Yoast/PHPUnit-Polyfills?branch=4.x)
 
 [![Minimum PHP Version](https://img.shields.io/packagist/dependency-v/yoast/phpunit-polyfills/php.svg)][Packagist]
 [![License: BSD3](https://img.shields.io/github/license/Yoast/PHPUnit-Polyfills)](https://github.com/Yoast/PHPUnit-Polyfills/blob/main/LICENSE)
@@ -34,7 +34,7 @@ Requirements
 ------------
 
 * PHP 7.1 or higher.
-* [PHPUnit] 7.5 - 9.x and 11.x (automatically required via Composer).
+* [PHPUnit] 7.5 - 9.x, 11.x and 12.x (automatically required via Composer).
 
 [PHPUnit]: https://packagist.org/packages/phpunit/phpunit
 
@@ -44,7 +44,7 @@ Installation
 
 To install this package, run:
 ```bash
-composer require --dev yoast/phpunit-polyfills:"^3.0"
+composer require --dev yoast/phpunit-polyfills:"^4.0"
 ```
 
 To update this package, run:
@@ -64,7 +64,7 @@ Why use the PHPUnit Polyfills?
 
 This library is set up to allow for creating PHPUnit cross-version compatible tests by offering a number of polyfills for functionality which was introduced, split up or renamed in PHPUnit.
 
-### Write your tests for PHPUnit 11.x and run them on PHPUnit 7.5 - 11.x
+### Write your tests for PHPUnit 12.x and run them on PHPUnit 7.5 - 12.x
 
 The polyfills have been setup to allow tests to be _forward_-compatible. What that means is, that your tests can use the assertions supported by the _latest_ PHPUnit version, even when running on older PHPUnit versions.
 
@@ -698,7 +698,7 @@ if ( defined( '\Yoast\PHPUnitPolyfills\Autoload::VERSION' ) === false
 }
 ```
 
-### Q: Why don't the PHPUnit Polyfills 3.x versions support running tests on PHPUnit 10 ?
+### Q: Why don't the PHPUnit Polyfills 3.x and 4.x versions support running tests on PHPUnit 10 ?
 
 PHPUnit 11.0 introduced the `expectUserDeprecationMessage*()` methods. To polyfill these for PHPUnit 10 would mean that the Polyfills package could no longer be a "drop-in" helper package, but would need to set extra requirements on test suites using the polyfills when used with PHPUnit 10 (like hooking into events or compulsory use of the `TestCase`s provided by this package).
 
@@ -706,7 +706,7 @@ As it was deemed desirable enough to polyfill the methods, the releases from the
 
 The impact of this compromise is minimal, as, in the most common case of running the tests with Composer installed dependencies, this just and only means that test runs on PHP 8.1 will use PHPUnit 9 instead of PHPUnit 10. There is no other impact.
 
-Keep in mind that functionality _added_ in PHPUnit 10, is still polyfilled and available in PHPUnit Polyfills 3.x.
+Keep in mind that functionality _added_ in PHPUnit 10, is still polyfilled and available in PHPUnit Polyfills 3.x/4.x.
 
 
 Contributing

--- a/phpunitpolyfills-autoload.php
+++ b/phpunitpolyfills-autoload.php
@@ -22,7 +22,7 @@ if ( \class_exists( 'Yoast\PHPUnitPolyfills\Autoload', false ) === false ) {
 		 *
 		 * @var string
 		 */
-		public const VERSION = '4.0.0-dev';
+		public const VERSION = '4.0.0';
 
 		/**
 		 * Loads a class.


### PR DESCRIPTION
Includes for the README:
* Updating the badge links
* Updating the warning about the TestListener polyfill not (yet) being compatible with PHPUnit 10/11/12.

Includes updating the `VERSION` constant in the `Autoload` class.