### PR TITLE
GH Actions: remove GH Token set via `env`

### DIFF
--- a/.github/workflows/cs.yml
+++ b/.github/workflows/cs.yml
@@ -34,7 +34,6 @@ jobs:
           tools: cs2pr
         env:
           fail-fast: true
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       # Install dependencies and handle caching in one go.
       # @link https://github.com/marketplace/actions/install-php-dependencies-with-composer
@@ -75,7 +74,6 @@ jobs:
           tools: phpstan:2.x
         env:
           fail-fast: true
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       # Install dependencies and handle caching in one go.
       # Dependencies need to be installed to make sure the PHPUnit classes are recognized.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -291,7 +291,6 @@ jobs:
           coverage: ${{ matrix.coverage && 'xdebug' || 'none' }}
         env:
           fail-fast: true
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       # YoastCS 3.0 has a PHP 7.2 minimum which conflicts with the requirements of this package.
       - name: 'Composer: remove YoastCS'


### PR DESCRIPTION
As of the release of `shivammathur/setup-php` v`2.35.0`, this should no longer be needed as the `setup-php` action runner will automatically use the `secrets.GITHUB_TOKEN` token.

Ref:
* https://github.com/shivammathur/setup-php/releases/tag/2.35.0
* https://github.com/shivammathur/setup-php/commit/55463ffe4fef24b158d1d7f861dce8b7d3811c13
