### PR TITLE
XTestCaseTest: update for PHPUnit 12.2.0

### DIFF
--- a/tests/TestCases/XTestCaseTest.php
+++ b/tests/TestCases/XTestCaseTest.php
@@ -99,13 +99,21 @@ final class XTestCaseTest extends XTestCase {
 	 *
 	 * @dataProvider dataHaveFixtureMethodsBeenTriggered
 	 *
-	 * @param int $expectedBeforeClass Value expected for the $beforeClass property.
-	 * @param int $expectedBefore      Value expected for the $before property.
-	 * @param int $expectedAfter       Value expected for the $after property.
+	 * @param int $expectedBeforeClass    Value expected for the $beforeClass property.
+	 * @param int $expectedBefore         Value expected for the $before property.
+	 * @param int $expectedAfter          Value expected for the $after property.
+	 * @param int $expectedPreConditions  Unused. "assertPreConditions" can not be triggered via annotations.
+	 * @param int $expectedPostConditions Unused. "assertPostConditions" can not be triggered via annotations.
 	 *
 	 * @return void
 	 */
-	public function testHaveFixtureMethodsBeenTriggered( $expectedBeforeClass, $expectedBefore, $expectedAfter ) {
+	public function testHaveFixtureMethodsBeenTriggered(
+		$expectedBeforeClass,
+		$expectedBefore,
+		$expectedAfter,
+		$expectedPreConditions, // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+		$expectedPostConditions // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+	) {
 		$this->assertSame(
 			$expectedBeforeClass,
 			self::$beforeClass,


### PR DESCRIPTION
> A warning is now emitted when a data provider provides data sets that have more values than the test method consumes using arguments

While not problematic for PHPUnit Polyfills 1.x - 3.x, this will fail tests for 4.x (without this change).

Ref: https://github.com/sebastianbergmann/phpunit/blob/12.2/ChangeLog-12.2.md#changed-1
