### PR TITLE
PHP 8.5 | Tests: prevent deprecation notice for Reflection*::setAccessible()

### DIFF
--- a/src/Helpers/AssertAttributeHelper.php
+++ b/src/Helpers/AssertAttributeHelper.php
@@ -49,7 +49,7 @@ trait AssertAttributeHelper {
 	public static function getProperty( $objInstance, $propertyName ) {
 		$reflect  = new ReflectionObject( $objInstance );
 		$property = $reflect->getProperty( $propertyName );
-		$property->setAccessible( true );
+		( \PHP_VERSION_ID < 80100 ) && $property->setAccessible( true );
 
 		return $property;
 	}


### PR DESCRIPTION
Since PHP 8.1, calling the `Reflection*::setAccessible()` methods is no longer necessary as reflected properties/methods/etc will always be accessible. However, the method calls are still needed for PHP < 8.1.

As of PHP 8.5, calling the `Reflection*::setAccessible()` methods is now formally deprecated and will yield a deprecation notice, which will fail test runs. As of PHP 9.0, the `setAccessible()` method(s) will be removed.

With the latter in mind, this commit prevents the deprecation notice by making the calls to `setAccessible()` conditional.

Silencing the deprecation would mean, this would need to be "fixed" again come PHP 9.0, while the current solution should be stable, including for PHP 9.0.

Ref: https://wiki.php.net/rfc/deprecations_php_8_5#extreflection_deprecations