### PR TITLE
GH Actions/markdown: "fail_on_error" is deprecated

### DIFF
--- a/.github/workflows/markdown.yml
+++ b/.github/workflows/markdown.yml
@@ -95,7 +95,7 @@ jobs:
         if: ${{ failure() && github.event_name == 'pull_request' }}
         uses: reviewdog/action-remark-lint@v5
         with:
-          fail_on_error: true
+          fail_level: warning
           install_deps: false
           level: info
           reporter: github-pr-check


### PR DESCRIPTION
... use `fail_level` instead.

Refs:
* https://github.com/reviewdog/action-remark-lint/releases/tag/v5.16.0
* reviewdog/action-remark-lint#100
