### PR TITLE
PHPCS: selectively ignore some flagged PHP function deprecations

### DIFF
--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -175,6 +175,12 @@
 		<exclude-pattern>/tests/*\.php$</exclude-pattern>
 	</rule>
 
+	<!-- These tests are limited via `@requires` tags and will only run on PHP versions where
+		 the functionality was not yet deprecated. -->
+	<rule ref="Generic.PHP.DeprecatedFunctions.Deprecated">
+		<exclude-pattern>/tests/Polyfills/AssertClosedResource(Curl|Finfo|Gd|XmlParser)Test\.php$</exclude-pattern>
+	</rule>
+
 	<!-- The use of `static` in the test cases is on purpose to test support. -->
 	<rule ref="Universal.CodeAnalysis.StaticInFinalClass">
 		<exclude-pattern>/tests/*</exclude-pattern>


### PR DESCRIPTION
The PHPCS native `Generic.PHP.DeprecatedFunctions` sniff will flag calls to deprecated functions.

As of PHP 8.5, PHP has deprecated a number of functions related to previously done resource to object migrations.

For the purposes of this package, we are testing the `assertClosedResource()` polyfill. These tests use a number of deprecated functions, but these tests will only ever be run on PHP versions where the return value from the involved extension was still a resource.

In other words, the PHP 8.5 deprecations will never be hit and the PHPCS sniff flagging them can be ignored.