### PR TITLE
PHPCS: fix up selective exclusion for 4.x

### DIFF
--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -141,7 +141,7 @@
 	<!-- These tests are limited via `@requires` tags and will only run on PHP versions where
 		 the functionality was not yet deprecated. -->
 	<rule ref="Generic.PHP.DeprecatedFunctions.Deprecated">
-		<exclude-pattern>/tests/Polyfills/AssertClosedResource(Curl|Finfo|Gd|XmlParser)Test\.php$</exclude-pattern>
+		<exclude-pattern>/tests/Polyfills/AssertClosedResource(Curl|Finfo|Gd|XmlParser)Test(Case)?\.php$</exclude-pattern>
 	</rule>
 
 	<!-- The use of `static` in the test cases is on purpose to test support. -->


### PR DESCRIPTION
Follow up on #274 and #247

<!--
REMINDER: Please target the **oldest** branch of the PHPUnit Polyfills that is affected by this issue.
-->
