### PR TITLE
GH Actions: allow testing this package with older PHPUnit versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -129,8 +129,10 @@ jobs:
       - name: Install Composer dependencies
         uses: "ramsey/composer-install@3cf229dc2919194e9e36783941438d17239e8520" # 3.1.1
         with:
+          # For PHP >= 7.2, which uses Composer >= 2.9.0 (automatically runs `audit`, we need to allow installing insecure packages
+          # to be able to test against older PHPUnit versions.
           # For PHP "nightly", we need to install with ignore platform reqs as not all dependencies may allow it yet.
-          composer-options: ${{ matrix.php == 'nightly' && '--ignore-platform-req=php+' || '' }}
+          composer-options: ${{ matrix.php >= '7.2' && '--no-security-blocking' || '' }} ${{ matrix.php == 'nightly' && '--ignore-platform-req=php+' || '' }}
           # Bust the cache at least once a month - output format: YYYY-MM.
           custom-cache-suffix: $(date -u "+%Y-%m")
 


### PR DESCRIPTION
PHPUnit recently published a CVE for a security flaw. And while end-users of this package are strongly recommended to use the latest point versions of PHPUnit to avoid that flaw, this package should still _support_ older PHPUnit versions and therefore we should ensure that the tests are run against older PHPUnit versions too.

What with Composer 2.9.0+ always running with `audit`, we need to explicitly allow Composer to install the specifically requested older (insecure) PHPUnit versions.

Also keep in mind that the vulnerability relates to `phpt` files, which are not in use in this repo, so running the tests against older PHPUnit versions does not actually open us up to security risks.

Ref: https://github.com/advisories/GHSA-vvj3-c3rp-c85p