### PR TITLE
Composer: update to YoastCS 3.3.0

### DIFF
--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -59,8 +59,12 @@
 		<!-- Exclude select "modern PHP" sniffs, which conflict with the minimum supported PHP version of this package. -->
 		<exclude name="SlevomatCodingStandard.Classes.ModernClassNameReference"/><!-- PHP 5.5+ -->
 		<exclude name="Modernize.FunctionCalls.Dirname.Nested"/><!-- PHP 7.0+. -->
+		<exclude name="SlevomatCodingStandard.ControlStructures.RequireNullCoalesceOperator"/><!-- PHP 7.0+. -->
 		<exclude name="PSR12.Properties.ConstantVisibility"/><!-- PHP 7.1+. -->
 		<exclude name="SlevomatCodingStandard.TypeHints.NullableTypeForNullDefaultValue"/><!-- PHP 7.1+. -->
+		<exclude name="SlevomatCodingStandard.Functions.RequireTrailingCommaInCall"/><!-- PHP 7.3+. -->
+		<exclude name="SlevomatCodingStandard.ControlStructures.RequireNullCoalesceEqualOperator"/><!-- PHP 7.4+. -->
+		<exclude name="SlevomatCodingStandard.Numbers.RequireNumericLiteralSeparator"/><!-- PHP 7.4+. -->
 
 		<!-- As this repo is about providing assertions, "mixed" is a perfectly valid type. -->
 		<exclude name="SlevomatCodingStandard.TypeHints.DisallowMixedTypeHint"/>

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
 	"require-dev": {
 		"php-parallel-lint/php-console-highlighter": "^1.0.0",
 		"php-parallel-lint/php-parallel-lint": "^1.4.0",
-		"yoast/yoastcs": "^3.2.0"
+		"yoast/yoastcs": "^3.3.0"
 	},
 	"minimum-stability": "dev",
 	"prefer-stable": true,


### PR DESCRIPTION
Includes excluding some newly added sniffs as they can't be applied yet due to this package adhering to a different minimum PHP version than most other Yoast packages.

Refs:
* https://github.com/Yoast/yoastcs/releases/tag/3.3.0
* https://github.com/PHPCSStandards/PHP_CodeSniffer/releases
* https://github.com/PHPCSStandards/phpcsutils/releases
* https://github.com/PHPCompatibility/PHPCompatibilityWP/releases
* https://github.com/automattic/VIP-Coding-Standards/releases
* https://github.com/sirbrillig/phpcs-variable-analysis/releases