### PR TITLE
Composer: update to YoastCS 3.4.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,9 +32,9 @@
 	"require-dev": {
 		"php-parallel-lint/php-console-highlighter": "^1.0.0",
 		"php-parallel-lint/php-parallel-lint": "^1.4.0",
-		"yoast/yoastcs": "^3.3.0"
+		"yoast/yoastcs": "^3.4.0"
 	},
-	"minimum-stability": "dev",
+	"minimum-stability": "alpha",
 	"prefer-stable": true,
 	"autoload": {
 		"files": [

--- a/tests/Polyfills/AssertClosedResourceCurlTest.php
+++ b/tests/Polyfills/AssertClosedResourceCurlTest.php
@@ -18,6 +18,8 @@ use Yoast\PHPUnitPolyfills\Polyfills\AssertClosedResource;
  *
  * @requires extension curl
  * @requires PHP < 8.0
+ *
+ * @phpcs:disable PHPCompatibility.FunctionUse.RemovedFunctions.curl_closeDeprecated -- These tests are only run on PHP < 8.0, so the PHP 8.5 deprecation is a non-issue.
  */
 final class AssertClosedResourceCurlTest extends AssertClosedResourceTestCase {
 

--- a/tests/Polyfills/AssertClosedResourceFinfoTest.php
+++ b/tests/Polyfills/AssertClosedResourceFinfoTest.php
@@ -18,6 +18,8 @@ use Yoast\PHPUnitPolyfills\Polyfills\AssertClosedResource;
  *
  * @requires extension finfo
  * @requires PHP < 8.1
+ *
+ * @phpcs:disable PHPCompatibility.FunctionUse.RemovedFunctions.finfo_closeDeprecated -- These tests are only run on PHP < 8.1, so the PHP 8.5 deprecation is a non-issue.
  */
 final class AssertClosedResourceFinfoTest extends AssertClosedResourceTestCase {
 

--- a/tests/Polyfills/AssertClosedResourceGdTest.php
+++ b/tests/Polyfills/AssertClosedResourceGdTest.php
@@ -18,6 +18,8 @@ use Yoast\PHPUnitPolyfills\Polyfills\AssertClosedResource;
  *
  * @requires extension gd
  * @requires PHP < 8.0
+ *
+ * @phpcs:disable PHPCompatibility.FunctionUse.RemovedFunctions.imagedestroyDeprecated -- These tests are only run on PHP < 8.0, so the PHP 8.5 deprecation is a non-issue.
  */
 final class AssertClosedResourceGdTest extends AssertClosedResourceTestCase {
 

--- a/tests/Polyfills/AssertClosedResourceXmlParserTest.php
+++ b/tests/Polyfills/AssertClosedResourceXmlParserTest.php
@@ -19,6 +19,8 @@ use Yoast\PHPUnitPolyfills\Polyfills\AssertClosedResource;
  *
  * @requires extension libxml
  * @requires PHP < 8.0
+ *
+ * @phpcs:disable PHPCompatibility.FunctionUse.RemovedFunctions.xml_parser_freeDeprecated -- These tests are only run on PHP < 8.0, so the PHP 8.5 deprecation is a non-issue.
  */
 final class AssertClosedResourceXmlParserTest extends AssertClosedResourceTestCase {
 

--- a/tests/Polyfills/ExpectPHPExceptionTest.php
+++ b/tests/Polyfills/ExpectPHPExceptionTest.php
@@ -68,12 +68,13 @@ final class ExpectPHPExceptionTest extends TestCase {
 		$this->expectErrorMessageMatches( '/foo/' );
 
 		if ( \PHP_VERSION_ID < 80400 ) {
+			// phpcs:ignore PHPCompatibility.ParameterValues.RemovedTriggerErrorLevel.Deprecated -- Used conditionally.
 			\trigger_error( 'foo', \E_USER_ERROR );
 		}
 		else {
 			// PHP 8.4 deprecates passing `E_USER_ERROR` to `trigger_error()`.
 			// Silence the deprecation notice (but not the error itself).
-			// phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged
+			// phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged,PHPCompatibility.ParameterValues.RemovedTriggerErrorLevel.Deprecated
 			@\trigger_error( 'foo', \E_USER_ERROR );
 		}
 	}

--- a/tests/Polyfills/Fixtures/ValueObjectNoReturnType.php
+++ b/tests/Polyfills/Fixtures/ValueObjectNoReturnType.php
@@ -6,6 +6,9 @@ use ClassWhichDoesntExist;
 
 /**
  * Fixture to test the AssertObjectEquals trait.
+ *
+ * This fixture is only used on PHP < 8.4. The `ValueObject` fixture is used for PHP 8.4+.
+ * @phpcs:disable PHPCompatibility.FunctionDeclarations.RemovedImplicitlyNullableParam.Deprecated
  */
 class ValueObjectNoReturnType {
 


### PR DESCRIPTION
This switches the package over to use the PHPCompatibility 10.0-alpha2 version, which should get much more extensive PHP cross-version compatibility issue detection.

Includes ignoring some flagged deprecations as these will not come into play (tests/fixtures which are only run/used on older PHP versions).

Refs:
* https://github.com/Yoast/yoastcs/releases/tag/3.4.0