### PR TITLE
Reusable remark workflow: bump Node from 20 to 24

### DIFF
--- a/.github/workflows/markdown.yml
+++ b/.github/workflows/markdown.yml
@@ -54,7 +54,7 @@ jobs:
       - name: Set up node and enable caching of dependencies
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: '20'
+          node-version: '24'
 
       # To make the command available on CLI, it needs to be installed globally.
       - name: Install Remark CLI globally


### PR DESCRIPTION
`dead-or-alive@1.0.5` (2026-06-03), pulled in transitively via `remark-lint-no-dead-urls`, bumped `undici` to `^8`. `undici@8` calls `markAsUncloneable`, a Node API only available from Node 22.10.0, so on Node 20 it fails with `TypeError: webidl.util.markAsUncloneable is not a function`, which has broken the `QA Markdown` job.