### PR TITLE
PHPStan config: update for fixes in PHPStan

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -34,12 +34,12 @@ parameters:
 			path: phpunitpolyfills-autoload.php
 		-
 			message: "`^Call to function method_exists\\(\\) with 'PHPUnit\\W+Framework\\W+Assert' and 'assertIsArray' will always evaluate to true\\.$`"
-			count: 2
+			count: 1
 			path: src/Polyfills/AssertIsList.php
 
 		-
 			message: '`^Call to static method PHPUnit\\Framework\\Assert::assertIsArray\(\) with mixed and mixed will always evaluate to false\.$`'
-			count: 2
+			count: 1
 			path: src/Polyfills/AssertIsList.php
 
 		# The traits are functionality, but not used by the package itself. Can't be helped.


### PR DESCRIPTION
Some ignored error patterns no longer occur in the latest PHPStan versions.