### PR TITLE
Composer: update to YoastCS 3.4.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
 	"require-dev": {
 		"php-parallel-lint/php-console-highlighter": "^1.0.0",
 		"php-parallel-lint/php-parallel-lint": "^1.4.0",
-		"yoast/yoastcs": "^3.4.0"
+		"yoast/yoastcs": "^3.4.2"
 	},
 	"minimum-stability": "alpha",
 	"prefer-stable": true,


### PR DESCRIPTION
A few dependencies of YoastCS have released security fixes.

This updates enforces the use of CS dependency versions which include these fixes.

Refs:
* https://github.com/Yoast/yoastcs/releases/tag/3.4.2

<!--
REMINDER: Please target the **oldest** branch of the PHPUnit Polyfills that is affected by this issue.
-->
