### PR TITLE
Composer: update to YoastCS 3.4.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
 	"require-dev": {
 		"php-parallel-lint/php-console-highlighter": "^1.0.0",
 		"php-parallel-lint/php-parallel-lint": "^1.4.0",
-		"yoast/yoastcs": "^3.4.2"
+		"yoast/yoastcs": "^3.4.3"
 	},
 	"minimum-stability": "alpha",
 	"prefer-stable": true,


### PR DESCRIPTION
PHP_CodeSniffer has released a security fix.

This updates enforces the use of a PHPCS version which include the fixes.

Refs:
* https://github.com/Yoast/yoastcs/releases/tag/3.4.3

<!--
REMINDER: Please target the **oldest** branch of the PHPUnit Polyfills that is affected by this issue.
-->
