### PR TITLE
Remark: skip flaky URL

### DIFF
--- a/.remarkrc
+++ b/.remarkrc
@@ -12,7 +12,8 @@
         "remark-lint-no-dead-urls",
         {
             "skipUrlPatterns": [
-                "^https?://github\\.com/Yoast/PHPUnit-Polyfills/compare/[0-9\\.]+?\\.{3}[0-9\\.]+"
+                "^https?://github\\.com/Yoast/PHPUnit-Polyfills/compare/[0-9\\.]+?\\.{3}[0-9\\.]+",
+                "^https://coveralls\\.io/github/Yoast/PHPUnit-Polyfills"
             ]
         }
     ],


### PR DESCRIPTION
The URL is correct, but Coveralls has started to throw 403 for automatic scans.

<!--
REMINDER: Please target the **oldest** branch of the PHPUnit Polyfills that is affected by this issue.
-->
